### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/jpablodrexler/aaf58f4b-bfb1-47e5-b4db-e3901cc5fb48/0b3e1f82-4359-4a71-9fa2-191c79553891/_apis/work/boardbadge/f84ef2a8-b659-48c5-816a-cd85c5ae0446)](https://dev.azure.com/jpablodrexler/aaf58f4b-bfb1-47e5-b4db-e3901cc5fb48/_boards/board/t/0b3e1f82-4359-4a71-9fa2-191c79553891/Microsoft.RequirementCategory)
 # JPPhotoManager
 
 ![JPPhotoManager](JPPhotoManager/Images/AppIcon.png)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#275](https://dev.azure.com/jpablodrexler/aaf58f4b-bfb1-47e5-b4db-e3901cc5fb48/_workitems/edit/275). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.