### PR TITLE
Thumbnail file per asset

### DIFF
--- a/JPPhotoManager/JPPhotoManager.Domain/Asset.cs
+++ b/JPPhotoManager/JPPhotoManager.Domain/Asset.cs
@@ -26,6 +26,11 @@ namespace JPPhotoManager.Domain
         public DateTime FileCreationDateTime { get; set; }
         public DateTime FileModificationDateTime { get; set; }
 
+        public static string GetThumbnailBlobName(string directoryName, string fileName)
+        {
+            return GetThumbnailBlobName(Path.Combine(directoryName, fileName));
+        }
+
         public static string GetThumbnailBlobName(string fullPath)
         {
             return fullPath.Replace(Path.PathSeparator, '_').Replace("\\", "_").Replace(":", "_") + ".bin";

--- a/JPPhotoManager/JPPhotoManager.Domain/Asset.cs
+++ b/JPPhotoManager/JPPhotoManager.Domain/Asset.cs
@@ -9,6 +9,7 @@ namespace JPPhotoManager.Domain
     {
         private const int MAX_PATH_LENGTH = 256;
 
+        public string AssetId { get; set; }
         public string FolderId { get; set; }
         public Folder Folder { get; set; }
         public string FileName { get; set; }
@@ -22,19 +23,9 @@ namespace JPPhotoManager.Domain
         public string Hash { get; set; }
         public BitmapImage ImageData { get; set; }
         public string FullPath => Folder != null ? Path.Combine(Folder.Path, FileName) : FileName;
-        public string ThumbnailBlobName => GetThumbnailBlobName(FullPath);
+        public string ThumbnailBlobName => AssetId + ".bin";
         public DateTime FileCreationDateTime { get; set; }
         public DateTime FileModificationDateTime { get; set; }
-
-        public static string GetThumbnailBlobName(string directoryName, string fileName)
-        {
-            return GetThumbnailBlobName(Path.Combine(directoryName, fileName));
-        }
-
-        public static string GetThumbnailBlobName(string fullPath)
-        {
-            return fullPath.Replace(Path.PathSeparator, '_').Replace("\\", "_").Replace(":", "_") + ".bin";
-        }
 
         public static bool IsValidBatchFormat(string batchFormat)
         {

--- a/JPPhotoManager/JPPhotoManager.Domain/Asset.cs
+++ b/JPPhotoManager/JPPhotoManager.Domain/Asset.cs
@@ -22,8 +22,14 @@ namespace JPPhotoManager.Domain
         public string Hash { get; set; }
         public BitmapImage ImageData { get; set; }
         public string FullPath => Folder != null ? Path.Combine(Folder.Path, FileName) : FileName;
+        public string ThumbnailBlobName => GetThumbnailBlobName(FullPath);
         public DateTime FileCreationDateTime { get; set; }
         public DateTime FileModificationDateTime { get; set; }
+
+        public static string GetThumbnailBlobName(string fullPath)
+        {
+            return fullPath.Replace(Path.PathSeparator, '_').Replace("\\", "_").Replace(":", "_") + ".bin";
+        }
 
         public static bool IsValidBatchFormat(string batchFormat)
         {

--- a/JPPhotoManager/JPPhotoManager.Domain/CatalogAssetsService.cs
+++ b/JPPhotoManager/JPPhotoManager.Domain/CatalogAssetsService.cs
@@ -385,6 +385,7 @@ namespace JPPhotoManager.Domain
 
                 asset = new Asset
                 {
+                    AssetId = Guid.NewGuid().ToString(),
                     FileName = Path.GetFileName(imagePath),
                     FolderId = folder.FolderId,
                     Folder = folder,

--- a/JPPhotoManager/JPPhotoManager.Domain/CatalogAssetsService.cs
+++ b/JPPhotoManager/JPPhotoManager.Domain/CatalogAssetsService.cs
@@ -146,21 +146,17 @@ namespace JPPhotoManager.Domain
             string[] fileNames = storageService.GetFileNames(directory);
             folder = assetRepository.GetFolderByPath(directory);
             List<Asset> cataloguedAssets = assetRepository.GetCataloguedAssets(directory);
-            bool folderHasThumbnails = assetRepository.FolderHasThumbnails(folder);
 
-            if (!folderHasThumbnails)
+            foreach (var asset in cataloguedAssets)
             {
-                foreach (var asset in cataloguedAssets)
-                {
-                    asset.ImageData = LoadThumbnail(directory, asset.FileName, asset.ThumbnailPixelWidth, asset.ThumbnailPixelHeight);
-                }
+                asset.ImageData = LoadThumbnail(directory, asset.FileName, asset.ThumbnailPixelWidth, asset.ThumbnailPixelHeight);
             }
 
-            cataloguedAssetsBatchCount = CatalogNewAssets(directory, callback, cataloguedAssetsBatchCount, batchSize, fileNames, cataloguedAssets, folderHasThumbnails);
-            cataloguedAssetsBatchCount = CatalogUpdatedAssets(directory, callback, cataloguedAssetsBatchCount, batchSize, fileNames, cataloguedAssets, folderHasThumbnails);
+            cataloguedAssetsBatchCount = CatalogNewAssets(directory, callback, cataloguedAssetsBatchCount, batchSize, fileNames, cataloguedAssets);
+            cataloguedAssetsBatchCount = CatalogUpdatedAssets(directory, callback, cataloguedAssetsBatchCount, batchSize, fileNames, cataloguedAssets);
             cataloguedAssetsBatchCount = CatalogDeletedAssets(directory, callback, cataloguedAssetsBatchCount, batchSize, fileNames, folder, cataloguedAssets);
 
-            if (assetRepository.HasChanges() || !folderHasThumbnails)
+            if (assetRepository.HasChanges())
             {
                 assetRepository.SaveCatalog(folder);
             }
@@ -234,7 +230,7 @@ namespace JPPhotoManager.Domain
             return cataloguedAssetsBatchCount;
         }
 
-        private int CatalogNewAssets(string directory, CatalogChangeCallback callback, int cataloguedAssetsBatchCount, int batchSize, string[] fileNames, List<Asset> cataloguedAssets, bool folderHasThumbnails)
+        private int CatalogNewAssets(string directory, CatalogChangeCallback callback, int cataloguedAssetsBatchCount, int batchSize, string[] fileNames, List<Asset> cataloguedAssets)
         {
             string[] newFileNames = directoryComparer.GetNewFileNames(fileNames, cataloguedAssets);
 
@@ -247,11 +243,7 @@ namespace JPPhotoManager.Domain
 
                 Asset newAsset = CreateAsset(directory, fileName);
                 newAsset.ImageData = LoadThumbnail(directory, fileName, newAsset.ThumbnailPixelWidth, newAsset.ThumbnailPixelHeight);
-
-                if (!folderHasThumbnails)
-                {
-                    cataloguedAssets.Add(newAsset);
-                }
+                cataloguedAssets.Add(newAsset);
 
                 callback?.Invoke(new CatalogChangeCallbackEventArgs
                 {
@@ -267,7 +259,7 @@ namespace JPPhotoManager.Domain
             return cataloguedAssetsBatchCount;
         }
 
-        private int CatalogUpdatedAssets(string directory, CatalogChangeCallback callback, int cataloguedAssetsBatchCount, int batchSize, string[] fileNames, List<Asset> cataloguedAssets, bool folderHasThumbnails)
+        private int CatalogUpdatedAssets(string directory, CatalogChangeCallback callback, int cataloguedAssetsBatchCount, int batchSize, string[] fileNames, List<Asset> cataloguedAssets)
         {
             string[] updatedFileNames = directoryComparer.GetUpdatedFileNames(fileNames, cataloguedAssets);
             Folder folder = assetRepository.GetFolderByPath(directory);
@@ -286,11 +278,7 @@ namespace JPPhotoManager.Domain
                 {
                     Asset updatedAsset = CreateAsset(directory, fileName);
                     updatedAsset.ImageData = LoadThumbnail(directory, fileName, updatedAsset.ThumbnailPixelWidth, updatedAsset.ThumbnailPixelHeight);
-
-                    if (!folderHasThumbnails)
-                    {
-                        cataloguedAssets.Add(updatedAsset);
-                    }
+                    cataloguedAssets.Add(updatedAsset);
 
                     callback?.Invoke(new CatalogChangeCallbackEventArgs
                     {

--- a/JPPhotoManager/JPPhotoManager.Domain/Folder.cs
+++ b/JPPhotoManager/JPPhotoManager.Domain/Folder.cs
@@ -4,7 +4,6 @@
     {
         public string FolderId { get; set; }
         public string Path { get; set; }
-        public string ThumbnailsFilename => FolderId + ".bin";
 
         public string Name
         {

--- a/JPPhotoManager/JPPhotoManager.Domain/Interfaces/IAssetRepository.cs
+++ b/JPPhotoManager/JPPhotoManager.Domain/Interfaces/IAssetRepository.cs
@@ -22,7 +22,6 @@ namespace JPPhotoManager.Domain.Interfaces
         bool HasChanges();
         bool ContainsThumbnail(string directoryName, string fileName);
         BitmapImage LoadThumbnail(string directoryName, string fileName, int width, int height);
-        bool FolderHasThumbnails(Folder folder);
         SyncAssetsConfiguration GetSyncAssetsConfiguration();
         void SaveSyncAssetsConfiguration(SyncAssetsConfiguration syncAssetsConfiguration);
         List<string> GetRecentTargetPaths();

--- a/JPPhotoManager/JPPhotoManager.Infrastructure/AssetRepository.cs
+++ b/JPPhotoManager/JPPhotoManager.Infrastructure/AssetRepository.cs
@@ -656,8 +656,7 @@ namespace JPPhotoManager.Infrastructure
 
             lock (syncLock)
             {
-                var fullPath = Path.Combine(directoryName, fileName);
-                var thumbnailBlobName = Asset.GetThumbnailBlobName(fullPath);
+                var thumbnailBlobName = Asset.GetThumbnailBlobName(directoryName, fileName);
 
                 if (!Thumbnails.ContainsKey(thumbnailBlobName))
                 {
@@ -677,8 +676,7 @@ namespace JPPhotoManager.Infrastructure
 
             lock (syncLock)
             {
-                var fullPath = Path.Combine(directoryName, fileName);
-                var thumbnailBlobName = Asset.GetThumbnailBlobName(fullPath);
+                var thumbnailBlobName = Asset.GetThumbnailBlobName(directoryName, fileName);
 
                 if (!Thumbnails.ContainsKey(thumbnailBlobName))
                 {

--- a/JPPhotoManager/JPPhotoManager.Infrastructure/AssetRepository.cs
+++ b/JPPhotoManager/JPPhotoManager.Infrastructure/AssetRepository.cs
@@ -662,19 +662,29 @@ namespace JPPhotoManager.Infrastructure
 
             lock (syncLock)
             {
-                var thumbnailBlobName = Asset.GetThumbnailBlobName(directoryName, fileName);
+                var folder = GetFolderByPath(directoryName);
 
-                if (!Thumbnails.ContainsKey(thumbnailBlobName))
+                if (folder != null)
                 {
-                    var thumbnail = (byte[])database.ReadBlob(thumbnailBlobName);
+                    var asset = GetAssetByFolderIdFileName(folder.FolderId, fileName);
 
-                    if (thumbnail != null)
+                    if (asset != null)
                     {
-                        Thumbnails[thumbnailBlobName] = thumbnail;
+                        var thumbnailBlobName = asset.ThumbnailBlobName;
+
+                        if (!Thumbnails.ContainsKey(thumbnailBlobName))
+                        {
+                            var thumbnail = (byte[])database.ReadBlob(thumbnailBlobName);
+
+                            if (thumbnail != null)
+                            {
+                                Thumbnails[thumbnailBlobName] = thumbnail;
+                            }
+                        }
+
+                        result = Thumbnails.ContainsKey(thumbnailBlobName);
                     }
                 }
-
-                result = Thumbnails.ContainsKey(thumbnailBlobName);
             }
 
             return result;
@@ -686,7 +696,9 @@ namespace JPPhotoManager.Infrastructure
 
             lock (syncLock)
             {
-                var thumbnailBlobName = Asset.GetThumbnailBlobName(directoryName, fileName);
+                var folder = GetFolderByPath(directoryName);
+                var asset = GetAssetByFolderIdFileName(folder.FolderId, fileName);
+                var thumbnailBlobName = asset.ThumbnailBlobName;
 
                 if (!Thumbnails.ContainsKey(thumbnailBlobName))
                 {
@@ -705,7 +717,6 @@ namespace JPPhotoManager.Infrastructure
                 else
                 {
                     DeleteAsset(directoryName, fileName);
-                    Folder folder = GetFolderByPath(directoryName);
                     SaveCatalog(folder);
                 }
             }

--- a/JPPhotoManager/JPPhotoManager.Infrastructure/AssetRepository.cs
+++ b/JPPhotoManager/JPPhotoManager.Infrastructure/AssetRepository.cs
@@ -79,6 +79,7 @@ namespace JPPhotoManager.Infrastructure
                 TableName = "Asset",
                 ColumnProperties = new ColumnProperties[]
                 {
+                    new ColumnProperties { ColumnName = "AssetId" },
                     new ColumnProperties { ColumnName = "FolderId" },
                     new ColumnProperties { ColumnName = "FileName" },
                     new ColumnProperties { ColumnName = "FileSize" },
@@ -188,16 +189,17 @@ namespace JPPhotoManager.Infrastructure
                 result = database.ReadObjectList("Asset", f =>
                     new Asset
                     {
-                        FolderId = f[0],
-                        FileName = f[1],
-                        FileSize = long.Parse(f[2]),
-                        ImageRotation = (Rotation)Enum.Parse(typeof(Rotation), f[3]),
-                        PixelWidth = int.Parse(f[4]),
-                        PixelHeight = int.Parse(f[5]),
-                        ThumbnailPixelWidth = int.Parse(f[6]),
-                        ThumbnailPixelHeight = int.Parse(f[7]),
-                        ThumbnailCreationDateTime = DateTime.Parse(f[8]),
-                        Hash = f[9]
+                        AssetId = f[0],
+                        FolderId = f[1],
+                        FileName = f[2],
+                        FileSize = long.Parse(f[3]),
+                        ImageRotation = (Rotation)Enum.Parse(typeof(Rotation), f[4]),
+                        PixelWidth = int.Parse(f[5]),
+                        PixelHeight = int.Parse(f[6]),
+                        ThumbnailPixelWidth = int.Parse(f[7]),
+                        ThumbnailPixelHeight = int.Parse(f[8]),
+                        ThumbnailCreationDateTime = DateTime.Parse(f[9]),
+                        Hash = f[10]
                     });
             }
             catch (ArgumentException ex)
@@ -281,16 +283,17 @@ namespace JPPhotoManager.Infrastructure
             {
                 return i switch
                 {
-                    0 => a.FolderId,
-                    1 => a.FileName,
-                    2 => a.FileSize,
-                    3 => a.ImageRotation,
-                    4 => a.PixelWidth,
-                    5 => a.PixelHeight,
-                    6 => a.ThumbnailPixelWidth,
-                    7 => a.ThumbnailPixelHeight,
-                    8 => a.ThumbnailCreationDateTime,
-                    9 => a.Hash,
+                    0 => a.AssetId,
+                    1 => a.FolderId,
+                    2 => a.FileName,
+                    3 => a.FileSize,
+                    4 => a.ImageRotation,
+                    5 => a.PixelWidth,
+                    6 => a.PixelHeight,
+                    7 => a.ThumbnailPixelWidth,
+                    8 => a.ThumbnailPixelHeight,
+                    9 => a.ThumbnailCreationDateTime,
+                    10 => a.Hash,
                     _ => throw new ArgumentOutOfRangeException(nameof(i))
                 };
             });

--- a/JPPhotoManager/JPPhotoManager.Tests/Integration/ApplicationTests.cs
+++ b/JPPhotoManager/JPPhotoManager.Tests/Integration/ApplicationTests.cs
@@ -313,18 +313,20 @@ namespace JPPhotoManager.Tests.Integration
 
     class UnencapsulatedAssetRepository : AssetRepository
     {
+        private readonly IDatabase _database;
+
         public UnencapsulatedAssetRepository(IDatabase database, IStorageService storageService, IUserConfigurationService userConfigurationService)
             : base(database, storageService, userConfigurationService)
         {
-
+            _database = database;
         }
 
         internal void RemoveThumbnail(string directoryName, string fileName)
         {
-            if (Thumbnails.ContainsKey(directoryName) && Thumbnails[directoryName].ContainsKey(fileName))
-            {
-                Thumbnails[directoryName].Remove(fileName);
-            }
+            var assets = GetAssets(directoryName);
+            var asset = assets.First(a => a.FileName == fileName);
+
+            DeleteThumbnail(asset);
         }
     }
 }


### PR DESCRIPTION
This change reduces the size of the data being written to the catalog when an asset is added or updated, so only the thumbnail for the asset is saved instead of the thumbnails for the whole folder. This is to optimize the usage of SSD.