### PR TITLE
Add web application documentation to root README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,3 +89,225 @@ Test data files (images, folders) live under `JPPhotoManager.Tests/TestFiles/`.
 - **Logging:** log4net throughout; use the existing logger pattern, not `Console.WriteLine`.
 - **DI registration:** New services should be registered as Singletons in `App.xaml.cs ConfigureServices()` following the existing pattern.
 - **MVVM:** All UI logic belongs in ViewModels; code-behind (`.xaml.cs`) is only for wiring or WPF-specific concerns.
+
+---
+
+# Web Application (JPPhotoManagerWeb)
+
+The web application lives under `JPPhotoManagerWeb/` and is split into two sub-projects:
+
+- **`backend/`** — Java 21 + Spring Boot 3.4 REST API
+- **`frontend/`** — Angular 19 SPA
+
+## Web Commands
+
+### Backend
+
+**Build:**
+```bash
+cd JPPhotoManagerWeb/backend
+mvn clean package -DskipTests
+```
+
+**Run:**
+```bash
+cd JPPhotoManagerWeb/backend
+mvn spring-boot:run
+```
+The API starts on `http://localhost:8080`.
+
+**Run all tests:**
+```bash
+cd JPPhotoManagerWeb/backend
+mvn test
+```
+
+**Run a single test class:**
+```bash
+cd JPPhotoManagerWeb/backend
+mvn test -Dtest=CatalogAssetsServiceImplTest
+```
+
+**Run a single test method:**
+```bash
+cd JPPhotoManagerWeb/backend
+mvn test -Dtest=CatalogAssetsServiceImplTest#methodName
+```
+
+### Frontend
+
+**Install dependencies:**
+```bash
+cd JPPhotoManagerWeb/frontend
+npm install
+```
+
+**Run dev server** (proxies `/api` to `localhost:8080`):
+```bash
+cd JPPhotoManagerWeb/frontend
+npm start
+```
+App available at `http://localhost:4200`.
+
+**Build for production:**
+```bash
+cd JPPhotoManagerWeb/frontend
+npm run build:prod
+```
+
+**Run tests:**
+```bash
+cd JPPhotoManagerWeb/frontend
+npm test
+```
+
+**Open Cypress UI:**
+```bash
+cd JPPhotoManagerWeb/frontend
+npm run cypress:open
+```
+
+**Lint:**
+```bash
+cd JPPhotoManagerWeb/frontend
+npm run lint
+```
+
+## Web Architecture
+
+Clean architecture mirroring the desktop app's layer separation across two sub-projects:
+
+### Backend
+
+```
+api/                  → REST controllers + request/response DTOs
+application/          → PhotoManagerFacade (orchestration) + application DTOs
+domain/
+  entity/             → JPA entities (Asset, Folder, …)
+  enums/              → ImageRotation, SortCriteria, WallpaperStyle, ReasonEnum
+  repository/         → Spring Data JPA interfaces
+  service/            → Domain service interfaces
+infrastructure/
+  service/            → Service implementations, StorageServiceImpl, ThumbnailStorageService
+config/               → AppConfig (CORS, async executor)
+```
+
+**Dependency flow:** `api` → `application` → `domain` ← `infrastructure`
+
+**Startup:** `PhotoManagerApplication.java` bootstraps Spring Boot; all beans are auto-detected via `@Service` / `@RestController`. The async thread pool and CORS policy are configured in `AppConfig`.
+
+**Key domain services** (interfaces in `domain/service/`, implementations in `infrastructure/service/`):
+- `CatalogAssetsService` — recursively scans folders, generates thumbnails (200×150 px), computes SHA-256 hashes, persists to DB; runs asynchronously and streams progress via `Consumer<CatalogChangeNotification>`
+- `SyncAssetsService` — copies new files between directory pairs, optionally deletes files missing from the source
+- `ConvertAssetsService` — converts PNG images to JPEG
+- `FindDuplicatedAssetsService` — groups assets by hash, filters out stale entries
+- `MoveAssetsService` — copies or moves files on disk and updates the DB record
+- `StorageService` — file I/O, thumbnail generation, EXIF rotation (Apache Commons Imaging), SHA-256
+
+**Persistence:** SQLite via Spring Data JPA + Hibernate community dialect. Database file: `~/.photomanager/photomanager.db`. Schema managed by Flyway; migrations in `src/main/resources/db/migration/`.
+
+**Real-time progress:** long-running operations (catalog, sync, convert) use Spring's `SseEmitter` to stream status events to the frontend.
+
+**Configuration:** `src/main/resources/application.yml`. Key properties:
+
+| Property | Default | Description |
+|---|---|---|
+| `photomanager.initial-directory` | `~/Pictures` | Starting folder shown in the UI |
+| `photomanager.root-catalog-folders` | `~/Pictures` | Semicolon-separated roots to catalog |
+| `photomanager.catalog-batch-size` | `1000` | Files processed per catalog pass |
+| `photomanager.thumbnails-directory` | `~/.photomanager/thumbnails` | Thumbnail storage path |
+
+### Frontend
+
+Angular 19 SPA using **standalone components** and **lazy-loaded routes**. No NgModules.
+
+```
+src/app/
+  app.component.ts/html/scss   → Shell with top navigation bar
+  app.routes.ts                → Lazy routes: /gallery, /sync, /convert, /duplicates
+  app.config.ts                → ApplicationConfig (HttpClient, Router, Animations)
+  core/
+    models/                    → TypeScript interfaces (Asset, Folder, PaginatedData, …)
+    services/                  → Angular services wrapping the backend API
+  features/
+    gallery/                   → Thumbnail grid + full-size viewer
+    folder-nav/                → Folder tree (Angular CDK FlatTreeControl)
+    sync/                      → Sync configuration and execution
+    convert/                   → Convert configuration and execution
+    duplicates/                → Duplicate detection and cleanup
+  shared/
+    components/thumbnail/      → Reusable thumbnail card component
+    pipes/file-size.pipe.ts    → Human-readable file size formatting
+```
+
+**Routing:**
+
+| Path | Component | Description |
+|---|---|---|
+| `/gallery` | `GalleryComponent` | Main photo browser (default) |
+| `/sync` | `SyncComponent` | Configure and run directory sync |
+| `/convert` | `ConvertComponent` | Configure and run PNG→JPEG conversion |
+| `/duplicates` | `DuplicatesComponent` | Find and remove duplicate images |
+
+## Web Testing Conventions
+
+### Backend
+
+Tests use **JUnit 5** + **Mockito** + **AssertJ**. Typical unit test pattern:
+
+```java
+@ExtendWith(MockitoExtension.class)
+class CatalogAssetsServiceImplTest {
+
+    @Mock StorageService storageService;
+    @Mock AssetRepository assetRepository;
+    @InjectMocks CatalogAssetsServiceImpl sut;
+
+    @Test
+    void methodName_condition_expectedResult() {
+        when(storageService.listFiles(any())).thenReturn(List.of("/photos/a.jpg"));
+        // ...
+        assertThat(result).isNotNull();
+    }
+}
+```
+
+Integration tests annotate with `@SpringBootTest` and use the `test` Spring profile (`application-test.yml`), which points at an in-memory SQLite database with Flyway disabled.
+
+### Frontend
+
+Tests use **Cypress Component Testing**. Typical component test pattern:
+
+```typescript
+it('methodName_condition_expectedResult', () => {
+  const assetService = { getAssets: cy.stub().returns(of({ assets: [], total: 0 })) } as Partial<AssetService>;
+  cy.mount(GalleryComponent, {
+    providers: [{ provide: AssetService, useValue: assetService }],
+  });
+  cy.get('.thumbnail-grid').should('exist');
+});
+```
+
+Tests use `cy.mount()`, Chai assertions, `Partial<Service>` stubs with `cy.stub()`, and `MockEventSource` for SSE flows. Test files are colocated with their source files as `*.cy.ts`.
+
+## Web Key Conventions
+
+### Backend
+
+- **Java version:** 21 (use records, sealed classes, pattern matching where appropriate).
+- **Lombok:** use `@Data`, `@RequiredArgsConstructor`, `@Slf4j` — avoid writing boilerplate manually.
+- **Logging:** use the SLF4J logger injected by `@Slf4j`, not `System.out`.
+- **Transactions:** read-only queries use `@Transactional(readOnly = true)`; writes use `@Transactional`.
+- **Async:** long-running methods are annotated `@Async` and return `CompletableFuture<T>`; the thread pool is configured in `AppConfig`.
+- **New services:** declare the interface in `domain/service/`, implement in `infrastructure/service/`, register with `@Service`. No manual bean registration needed.
+- **New endpoints:** add a `@RestController` in `api/`; keep controllers thin (delegate immediately to `PhotoManagerFacade`).
+
+### Frontend
+
+- **Standalone components only** — never add `NgModule`.
+- **Strict TypeScript** — `strict: true` in `tsconfig.json`; no `any` unless unavoidable.
+- **Angular control flow** — use `@if`, `@for`, `@switch` (Angular 17+ syntax); avoid `*ngIf` / `*ngFor` directives.
+- **Angular Material** — use Material components for all UI elements; import only the specific Material modules each component needs.
+- **New features** — add a folder under `features/`, create a standalone component, and register a lazy route in `app.routes.ts`.
+- **New API calls** — add a method to the relevant service in `core/services/`; keep HTTP logic out of components.
+- **Styles** — global styles in `src/styles.scss`; component-specific styles in the component's `.scss` file.

--- a/Readme.md
+++ b/Readme.md
@@ -38,3 +38,50 @@ Open the solution file `JPPhotoManager/JPPhotoManager.sln` and run the `JPPhotoM
 * [Octokit.net](https://octokitnet.readthedocs.io/en/latest/)
 * [coverlet](https://github.com/coverlet-coverage/coverlet)
 * [ReportGenerator](https://github.com/danielpalme/ReportGenerator)
+
+---
+
+## Web Application
+
+JPPhotoManager Web is a browser-based rewrite of the desktop application, built with a **Java 21 + Spring Boot 3** REST API backend and an **Angular 19** single-page application frontend.
+
+### Features
+* Visualization of image galleries (thumbnail grid and full-size viewer)
+* Find duplicates
+* Copy/move images between folders
+* Sync images between directory pairs
+* Convert PNG images to JPEG
+* Streaming real-time progress for long-running operations via Server-Sent Events
+
+### Run the web application
+
+**Backend** (requires Java 21 and Maven 3.9+):
+```bash
+cd JPPhotoManagerWeb/backend
+mvn spring-boot:run
+```
+The API starts at `http://localhost:8080`.
+
+**Frontend** (requires Node.js 22):
+```bash
+cd JPPhotoManagerWeb/frontend
+npm install
+npm start
+```
+Open `http://localhost:4200` in your browser. The dev server automatically proxies `/api` requests to the backend.
+
+### Technologies used (web application)
+* [Java 21](https://openjdk.org/)
+* [Spring Boot 3](https://spring.io/projects/spring-boot)
+* [Spring Data JPA](https://spring.io/projects/spring-data-jpa)
+* [SQLite](https://www.sqlite.org/index.html)
+* [Flyway](https://flywaydb.org/)
+* [Lombok](https://projectlombok.org/)
+* [MapStruct](https://mapstruct.org/)
+* [Apache Commons Imaging](https://commons.apache.org/proper/commons-imaging/)
+* [Angular 19](https://angular.dev/)
+* [Angular Material](https://material.angular.io/)
+* [Cypress](https://www.cypress.io/)
+* [JUnit 5](https://junit.org/junit5/)
+* [Mockito](https://site.mockito.org/)
+* [AssertJ](https://assertj.github.io/doc/)


### PR DESCRIPTION
Documents the JPPhotoManagerWeb Java/Spring Boot + Angular stack alongside
the existing desktop app docs: commands, architecture, testing conventions,
key conventions, features, run instructions, and technologies used.

https://claude.ai/code/session_012iCUv45GtAW2sRictUEGof