### PR TITLE
Add Java 21 + Spring Boot 3 backend and Angular 19 frontend scaffold

### DIFF
--- a/JPPhotoManagerWeb/CLAUDE.md
+++ b/JPPhotoManagerWeb/CLAUDE.md
@@ -75,9 +75,9 @@ config/               → AppConfig (CORS, async executor)
 
 **Persistence:** PostgreSQL via Spring Data JPA + Hibernate. Schema managed by **Flyway**; migrations live in `src/main/resources/db/migration/`. Connection is configured via environment variables (see table below).
 
-**Local development prerequisite:** PostgreSQL 15+ must be running. Quickstart:
+**Local development prerequisite:** PostgreSQL 18+ must be running. Quickstart:
 ```bash
-docker run -d --name photomanager-db -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=photomanager -p 5432:5432 postgres:15
+docker run -d --name photomanager-db -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=photomanager -p 5432:5432 postgres:18
 ```
 
 **Thumbnails:** stored as `{assetId}.bin` files under `~/.photomanager/thumbnails/` managed by `ThumbnailStorageService`.

--- a/JPPhotoManagerWeb/backend/pom.xml
+++ b/JPPhotoManagerWeb/backend/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.4</version>
+        <version>3.5.14</version>
         <relativePath/>
     </parent>
 
@@ -21,6 +21,7 @@
         <java.version>21</java.version>
         <mapstruct.version>1.6.3</mapstruct.version>
         <lombok.version>1.18.46</lombok.version>
+        <flyway.version>12.5.0</flyway.version>
     </properties>
 
     <dependencies>

--- a/JPPhotoManagerWeb/backend/src/test/java/com/jpablodrexler/photomanager/PostgresIntegrationTest.java
+++ b/JPPhotoManagerWeb/backend/src/test/java/com/jpablodrexler/photomanager/PostgresIntegrationTest.java
@@ -14,5 +14,5 @@ public abstract class PostgresIntegrationTest {
 
     @Container
     @ServiceConnection
-    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15");
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:18");
 }


### PR DESCRIPTION
Introduces two new application layers for migrating the WPF desktop app:

backend/ — Spring Boot 3.4 REST API with Java 21
- Domain entities (Asset, Folder, SyncAssetsDirectoriesDefinition, ConvertAssetsDirectoriesDefinition, RecentTargetPath)
- Enums matching the original C# enumerations (ImageRotation, SortCriteria, WallpaperStyle, ReasonEnum)
- Spring Data JPA repositories with SQLite via Flyway migrations
- Service interfaces and infrastructure implementations for catalog, sync, convert, move, duplicate detection
- REST controllers for assets, folders, sync, and convert with Server-Sent Events for long-running operations
- StorageServiceImpl with EXIF rotation support (Apache Commons Imaging) and thumbnail generation
- application.yml configured for SQLite persistence and async task execution

frontend/ — Angular 19 SPA with Angular Material
- Standalone components with lazy-loaded routes (gallery, sync, convert, duplicates)
- Core services (AssetService, FolderService, SyncService, ConvertService) calling the backend API
- GalleryComponent with thumbnail grid, image viewer, pagination, sorting, and real-time catalog SSE
- FolderNavComponent using Angular CDK FlatTreeControl
- SyncComponent and ConvertComponent with configure → run → results flow using SSE
- DuplicatesComponent for hash-based duplicate detection and cleanup
- ThumbnailComponent (shared) and FileSizePipe
- Proxy config forwarding /api calls to localhost:8080

https://claude.ai/code/session_01XJXdFufgRiTV6gC39MMWPL