### PR TITLE
Add Java 21 + Spring Boot 3 backend and Angular 19 frontend scaffold

### DIFF
--- a/JPPhotoManagerWeb/CLAUDE.md
+++ b/JPPhotoManagerWeb/CLAUDE.md
@@ -48,30 +48,73 @@ mvn test -Dtest=CatalogAssetsServiceImplTest#methodName
 
 ### Architecture
 
-Clean architecture in a single Maven module (`com.jpablodrexler.photo-manager`), mirroring the original desktop app's layer separation:
+**Hexagonal Architecture** (Ports & Adapters) in a single Maven module (`com.jpablodrexler.photo-manager`). The domain is completely free of framework dependencies; all Spring, JPA, and file-I/O concerns live exclusively in the `infrastructure/` package tree.
 
 ```
-api/                  → REST controllers + request/response DTOs
-application/          → PhotoManagerFacade (orchestration) + application DTOs
 domain/
-  entity/             → JPA entities (Asset, Folder, …)
+  model/              → Plain POJO domain objects (Asset, Folder, Album, User…)
+  port/
+    in/               → Use-case interfaces (driving ports) — one interface, one method each
+      asset/          →   GetAssetsUseCase, GetAssetImageUseCase, GetAssetExifUseCase,
+                          DownloadAssetsUseCase, RateAssetUseCase, MoveAssetsUseCase,
+                          UploadAssetUseCase, DeleteAssetsUseCase
+      catalog/        →   CatalogAssetsUseCase, GetDuplicatedAssetsUseCase
+      album/          →   GetAlbumsUseCase, CreateAlbumUseCase, GetAlbumUseCase,
+                          UpdateAlbumUseCase, DeleteAlbumUseCase,
+                          AddAssetsToAlbumUseCase, RemoveAssetsFromAlbumUseCase
+      sync/           →   GetSyncConfigUseCase, SaveSyncConfigUseCase, SyncAssetsUseCase
+      convert/        →   GetConvertConfigUseCase, SaveConvertConfigUseCase, ConvertAssetsUseCase
+      folder/         →   GetSubFoldersUseCase, GetDrivesUseCase,
+                          GetInitialFolderUseCase, GetRecentTargetPathsUseCase
+      recycle/        →   GetDeletedAssetsUseCase, RestoreAssetsUseCase, PurgeAssetsUseCase
+      search/         →   GetSearchPresetsUseCase, CreateSearchPresetUseCase, DeleteSearchPresetUseCase
+      home/           →   GetHomeStatsUseCase
+      user/           →   ListUsersUseCase, CreateUserUseCase, UpdatePasswordUseCase, DeleteUserUseCase
+    out/              → Secondary port interfaces (driven ports) — plain Java only
+                        AssetRepositoryPort, FolderRepositoryPort, AlbumRepositoryPort,
+                        StoragePort, ThumbnailPort, HashCalculatorPort, JwtTokenPort…
+  service/            → Stateless pure-domain logic (FindDuplicatedAssetsService)
   enums/              → ImageRotation, SortCriteria, WallpaperStyle, ReasonEnum
-  repository/         → Spring Data JPA interfaces
-  service/            → Domain service interfaces
+
+application/
+  dto/                → Framework-free application DTOs (AssetFilter, PaginatedResult,
+                        CatalogChangeNotification, SyncAssetsResult…)
+  usecase/            → One implementation class per interface (@Service @Transactional only)
+    asset/   catalog/   album/   sync/   convert/
+    folder/  recycle/   search/  home/   user/   ← mirrors port/in subpackage layout
+
 infrastructure/
-  service/            → Service implementations, StorageServiceImpl, ThumbnailStorageService
-config/               → AppConfig (CORS, async executor)
+  persistence/
+    entity/           → @Entity JPA classes (AssetEntity, FolderEntity…)
+    jpa/              → Spring Data JPA interfaces (JpaAssetRepository…)
+    adapter/          → Implements domain/port/out persistence ports
+    mapper/           → Entity ↔ domain model conversions
+  web/
+    controller/       → @RestController primary adapters (AssetController…)
+    dto/              → HTTP request/response DTOs
+    mapper/           → Domain model ↔ HTTP DTO conversions
+    exception/        → GlobalExceptionHandler, domain exceptions
+  service/            → Secondary service adapters (StorageServiceAdapter,
+                        ThumbnailStorageServiceAdapter, JwtTokenAdapter,
+                        CatalogScheduler, JwtAuthenticationFilter…)
+  config/             → AppConfig, SecurityConfig, DataInitializer, UserConfig
 ```
 
-**Dependency flow:** `api` → `application` → `domain` ← `infrastructure`
+**Dependency flow:** Primary Adapters → `port/in` → Use Cases → `port/out` ← Secondary Adapters
 
-**Key domain services** (interfaces in `domain/service/`, implementations in `infrastructure/service/`):
-- `CatalogAssetsService` — recursively scans folders, generates thumbnails (200×150 px), computes SHA-256 hashes, persists to DB; runs asynchronously and streams progress via `Consumer<CatalogChangeNotification>`
-- `SyncAssetsService` — copies new files between directory pairs, optionally deletes files missing from the source
-- `ConvertAssetsService` — converts PNG images to JPEG
-- `FindDuplicatedAssetsService` — groups assets by hash, filters out stale entries
-- `MoveAssetsService` — copies or moves files on disk and updates the DB record
-- `StorageService` — file I/O, thumbnail generation, EXIF rotation (Apache Commons Imaging), SHA-256
+**Key rules when adding code:**
+- `domain/` must have zero `jakarta.*` or `org.springframework.*` imports.
+- `domain/port/out/` interfaces use plain Java types — never `JpaRepository`, `Page`, or `Pageable`.
+- `application/usecase/` implementations may only carry `@Service` and `@Transactional` — no other Spring annotations.
+- All `@Entity`, `@RestController`, and Spring Data repository interfaces belong exclusively in `infrastructure/`.
+
+**Key use cases** (interfaces in `domain/port/in/`, implementations in `application/usecase/`):
+- `CatalogAssetsUseCase` — recursively scans folders, generates thumbnails (200×150 px), computes SHA-256 hashes, persists to DB; runs asynchronously and streams progress via `Consumer<CatalogChangeNotification>`
+- `SyncAssetsUseCase` — copies new files between directory pairs, optionally deletes files missing from the source
+- `ConvertAssetsUseCase` — converts PNG images to JPEG
+- `GetDuplicatedAssetsUseCase` — groups assets by hash, filters out stale entries
+- `MutateAssetsUseCase` — move, copy, rate, upload, and delete assets
+- `StoragePort` / `StorageServiceAdapter` — file I/O, thumbnail generation, EXIF rotation (Apache Commons Imaging), SHA-256
 
 **Persistence:** PostgreSQL via Spring Data JPA + Hibernate. Schema managed by **Flyway**; migrations live in `src/main/resources/db/migration/`. Connection is configured via environment variables (see table below).
 
@@ -143,19 +186,19 @@ The app uses **JWT stored in an HttpOnly cookie** (`SameSite=Strict`, `Path=/`).
 
 ### Testing Conventions
 
-Tests use **JUnit 5** + **Mockito** + **AssertJ**. Typical unit test pattern:
+Tests use **JUnit 5** + **Mockito** + **AssertJ**. Mock the domain port interfaces — never Spring Data repository interfaces or concrete implementations. Typical unit test pattern:
 
 ```java
 @ExtendWith(MockitoExtension.class)
-class CatalogAssetsServiceImplTest {
+class CatalogAssetsUseCaseImplTest {
 
-    @Mock StorageService storageService;
-    @Mock AssetRepository assetRepository;
-    @InjectMocks CatalogAssetsServiceImpl sut;
+    @Mock StoragePort storagePort;
+    @Mock AssetRepositoryPort assetRepository;
+    @InjectMocks CatalogAssetsUseCaseImpl sut;
 
     @Test
     void methodName_condition_expectedResult() {
-        when(storageService.listFiles(any())).thenReturn(List.of("/photos/a.jpg"));
+        when(storagePort.listFiles(any())).thenReturn(List.of("/photos/a.jpg"));
         // ...
         assertThat(result).isNotNull();
     }
@@ -171,8 +214,9 @@ Integration tests annotate with `@SpringBootTest`, extend `PostgresIntegrationTe
 - **Transactions:** read-only queries use `@Transactional(readOnly = true)`; writes use `@Transactional`.
 - **Async:** long-running methods are annotated `@Async` and return `CompletableFuture<T>`; the thread pool is configured in `AppConfig`.
 - **Logging:** use the SLF4J logger injected by `@Slf4j`, not `System.out`.
-- **New services:** declare the interface in `domain/service/`, implement in `infrastructure/service/`, and let Spring autowire via the interface. No manual bean registration needed — `@Service` is sufficient.
-- **New endpoints:** add a `@RestController` in `api/`; keep controllers thin (delegate immediately to `PhotoManagerFacade`).
+- **New use case:** declare a single-method interface in `domain/port/in/<subpackage>/`; create one implementation class in the mirrored `application/usecase/<subpackage>/` path (annotate `@Service @Transactional` only; inject only `domain/port/out/` interfaces); inject the interface into the relevant controller in `infrastructure/web/controller/`.
+- **New secondary service:** declare a driven port interface in `domain/port/out/`; implement it as an adapter in `infrastructure/service/` or `infrastructure/persistence/adapter/` (annotate `@Service`; all framework imports stay here).
+- **New endpoints:** add a `@RestController` in `infrastructure/web/controller/`; keep controllers thin (translate HTTP ↔ domain types via `infrastructure/web/mapper/`, then delegate to use-case interfaces).
 
 ---
 

--- a/JPPhotoManagerWeb/README.md
+++ b/JPPhotoManagerWeb/README.md
@@ -101,39 +101,62 @@ graph TB
     SpringBoot -->|"File I/O"| FS
 ```
 
-### Backend Layer Architecture
+### Backend Architecture (Hexagonal / Ports & Adapters)
 
-The backend follows **clean architecture** with strict, unidirectional layer dependencies:
+The backend follows **Hexagonal Architecture** (also called Ports & Adapters). The domain sits at the centre and is completely free of framework dependencies. All Spring, JPA, and file-I/O concerns live in the infrastructure layer and communicate with the domain only through explicit port interfaces.
 
 ```mermaid
 graph LR
-    subgraph A["api/"]
-        C["Controllers\n+ Request/Response DTOs"]
-    end
-    subgraph APP["application/"]
-        F["PhotoManagerFacade\n(orchestration)"]
-        ADTO["Application DTOs\n(CatalogChangeNotification,\nPaginatedData…)"]
-    end
-    subgraph D["domain/"]
-        SI["Service Interfaces\n(CatalogAssetsService,\nSyncAssetsService…)"]
-        RI["Repository Interfaces\n(AssetRepository,\nFolderRepository…)"]
-        E["Entities & Enums\n(Asset, Folder,\nAlbum, User…)"]
-    end
-    subgraph I["infrastructure/"]
-        SImpl["Service Implementations\n(CatalogAssetsServiceImpl,\nStorageServiceImpl…)"]
-        Sec["Security\n(JwtUtil,\nJwtAuthenticationFilter)"]
+    subgraph Primary["Primary Adapters — Driving"]
+        WEB["infrastructure/web/controller/\nAssetController · AlbumController\nFolderController · SyncController…"]
+        SCHED["infrastructure/service/\nCatalogScheduler"]
     end
 
-    C --> F
-    F --> SI
-    F --> ADTO
-    SImpl -.->|"implements"| SI
-    SImpl --> RI
-    SImpl --> E
-    RI --> E
+    subgraph Hexagon["Domain Hexagon"]
+        subgraph PortIn["domain/port/in — Driving Ports"]
+            UC["asset/ · catalog/ · album/ · sync/\nconvert/ · folder/ · recycle/\nsearch/ · home/ · user/\n38 single-method interfaces"]
+        end
+        subgraph DomainCore["domain core"]
+            MODEL["domain/model/\nAsset · Folder · Album\nUser · SearchPreset…"]
+            DSVC["domain/service/\nFindDuplicatedAssetsService"]
+        end
+        subgraph PortOut["domain/port/out — Driven Ports"]
+            REPO_P["AssetRepositoryPort\nFolderRepositoryPort\nAlbumRepositoryPort\n… 11 repository ports"]
+            SVC_P["StoragePort · ThumbnailPort\nHashCalculatorPort · JwtTokenPort"]
+        end
+    end
+
+    subgraph AppLayer["application/usecase/"]
+        IMPL["38 implementation classes\none per interface\n(@Service @Transactional only)"]
+    end
+
+    subgraph Secondary["Secondary Adapters — Driven"]
+        JPA["infrastructure/persistence/adapter/\nAssetRepositoryAdapter\nFolderRepositoryAdapter…\n(Spring Data JPA)"]
+        SRVC["infrastructure/service/\nStorageServiceAdapter\nThumbnailStorageServiceAdapter\nJwtTokenAdapter"]
+    end
+
+    HTTP[/"Angular SPA\nHTTP · SSE"/] --> WEB
+    TIMER[/"Spring Scheduler"/] --> SCHED
+    WEB -->|"port/in"| UC
+    SCHED -->|"port/in"| UC
+    UC --> IMPL
+    IMPL --> MODEL
+    IMPL --> DSVC
+    IMPL -->|"port/out"| REPO_P
+    IMPL -->|"port/out"| SVC_P
+    JPA -.->|"implements"| REPO_P
+    SRVC -.->|"implements"| SVC_P
+    JPA --> PG[("PostgreSQL")]
+    SRVC --> FS[("File System")]
 ```
 
-**Dependency flow:** `api` → `application` → `domain` ← `infrastructure` — the domain layer has no outward dependencies.
+**Key rules:**
+- `domain/` has zero `jakarta.*` or `org.springframework.*` imports.
+- `domain/port/out/` interfaces use plain Java types only — no `JpaRepository`, `Page`, or `Pageable`.
+- `application/usecase/` implementations carry `@Service` and `@Transactional` only — no other Spring annotations, no HTTP types.
+- `infrastructure/` is the only layer allowed to import Spring, JPA, Jackson, and external libraries.
+
+**Dependency flow:** Primary Adapters → `port/in` → Use Cases → `port/out` ← Secondary Adapters — the domain hexagon has no outward framework dependencies.
 
 ### Database Schema
 

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/application/dto/AssetFilter.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/application/dto/AssetFilter.java
@@ -1,0 +1,17 @@
+package com.jpablodrexler.photomanager.application.dto;
+
+import com.jpablodrexler.photomanager.domain.enums.SortCriteria;
+
+import java.time.LocalDate;
+
+public record AssetFilter(
+        Long folderId,
+        String search,
+        LocalDate dateFrom,
+        LocalDate dateTo,
+        Integer minRating,
+        SortCriteria sortCriteria,
+        int page,
+        int pageSize,
+        boolean includeDeleted
+) {}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/application/dto/PaginatedResult.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/application/dto/PaginatedResult.java
@@ -1,0 +1,5 @@
+package com.jpablodrexler.photomanager.application.dto;
+
+import java.util.List;
+
+public record PaginatedResult<T>(List<T> items, long total, int page, int pageSize) {}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/Album.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/Album.java
@@ -1,0 +1,24 @@
+package com.jpablodrexler.photomanager.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Album {
+
+    private Long albumId;
+    private UUID userId;
+    private String name;
+    private String description;
+    private Instant createdAt;
+    private List<Long> assetIds;
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/Asset.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/Asset.java
@@ -1,0 +1,40 @@
+package com.jpablodrexler.photomanager.domain.model;
+
+import com.jpablodrexler.photomanager.domain.enums.ImageRotation;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Asset {
+
+    private Long assetId;
+    private Folder folder;
+    private String fileName;
+    private long fileSize;
+    private Integer pixelWidth;
+    private Integer pixelHeight;
+    private Integer thumbnailPixelWidth;
+    private Integer thumbnailPixelHeight;
+    private ImageRotation imageRotation;
+    private LocalDateTime thumbnailCreationDateTime;
+    private String hash;
+    private LocalDateTime fileCreationDateTime;
+    private LocalDateTime fileModificationDateTime;
+    private LocalDateTime deletedAt;
+    private int rating;
+
+    public String getThumbnailBlobName() {
+        return assetId + ".bin";
+    }
+
+    public String getFullPath() {
+        return folder != null ? folder.getPath() + "/" + fileName : fileName;
+    }
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/AssetExif.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/AssetExif.java
@@ -1,0 +1,29 @@
+package com.jpablodrexler.photomanager.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AssetExif {
+
+    private Long assetId;
+    private String cameraMake;
+    private String cameraModel;
+    private String lensModel;
+    private String exposureTime;
+    private Double fNumber;
+    private Double focalLength;
+    private Integer isoSpeed;
+    private LocalDateTime dateTaken;
+    private Integer widthPixels;
+    private Integer heightPixels;
+    private Double gpsLatitude;
+    private Double gpsLongitude;
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/CatalogRunState.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/CatalogRunState.java
@@ -1,0 +1,22 @@
+package com.jpablodrexler.photomanager.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CatalogRunState {
+
+    private Integer id;
+    private boolean running;
+    private Instant startedAt;
+    private Instant lastHeartbeatAt;
+    private String instanceId;
+    private Instant lastCompletedAt;
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/ConvertDirectoriesDefinition.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/ConvertDirectoriesDefinition.java
@@ -1,0 +1,20 @@
+package com.jpablodrexler.photomanager.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConvertDirectoriesDefinition {
+
+    private Long id;
+    private String sourceDirectory;
+    private String destinationDirectory;
+    private boolean includeSubFolders;
+    private boolean deleteAssetsNotInSource;
+    private int order;
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/Folder.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/Folder.java
@@ -1,0 +1,39 @@
+package com.jpablodrexler.photomanager.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Folder {
+
+    private Long folderId;
+    private String path;
+
+    public String getName() {
+        if (path == null || path.isBlank())
+            return "";
+        Path p = Paths.get(path);
+        return p.getFileName() != null ? p.getFileName().toString() : path;
+    }
+
+    public String getParentPath() {
+        if (path == null || path.isBlank())
+            return null;
+        Path p = Paths.get(path);
+        return p.getParent() != null ? p.getParent().toString() : null;
+    }
+
+    public boolean isParentOf(Folder other) {
+        if (other == null || other.path == null)
+            return false;
+        return other.path.startsWith(this.path + "/") || other.path.startsWith(this.path + "\\");
+    }
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/RecentTargetPath.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/RecentTargetPath.java
@@ -1,0 +1,20 @@
+package com.jpablodrexler.photomanager.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecentTargetPath {
+
+    private Long id;
+    private String path;
+
+    public RecentTargetPath(String path) {
+        this.path = path;
+    }
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/RefreshToken.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/RefreshToken.java
@@ -1,0 +1,23 @@
+package com.jpablodrexler.photomanager.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshToken {
+
+    private Long tokenId;
+    private UUID userId;
+    private String token;
+    private Instant expiresAt;
+    private boolean revoked;
+    private Instant issuedAt;
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/SearchPreset.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/SearchPreset.java
@@ -1,0 +1,22 @@
+package com.jpablodrexler.photomanager.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchPreset {
+
+    private Long presetId;
+    private UUID userId;
+    private String name;
+    private String filterJson;
+    private Instant createdAt;
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/SyncDirectoriesDefinition.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/SyncDirectoriesDefinition.java
@@ -1,0 +1,20 @@
+package com.jpablodrexler.photomanager.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SyncDirectoriesDefinition {
+
+    private Long id;
+    private String sourceDirectory;
+    private String destinationDirectory;
+    private boolean includeSubFolders;
+    private boolean deleteAssetsNotInSource;
+    private int order;
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/User.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/User.java
@@ -1,0 +1,22 @@
+package com.jpablodrexler.photomanager.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+
+    private UUID id;
+    private String username;
+    private String passwordHash;
+    private Instant createdAt;
+    private String role;
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/AlbumRepositoryPort.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/AlbumRepositoryPort.java
@@ -1,0 +1,20 @@
+package com.jpablodrexler.photomanager.domain.port.out;
+
+import com.jpablodrexler.photomanager.application.dto.PaginatedResult;
+import com.jpablodrexler.photomanager.domain.model.Album;
+import com.jpablodrexler.photomanager.domain.model.Asset;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface AlbumRepositoryPort {
+    List<Album> findByUserId(UUID userId);
+    Optional<Album> findByIdAndUserId(Long albumId, UUID userId);
+    PaginatedResult<Asset> findAlbumAssets(Long albumId, int page, int pageSize);
+    long countAssets(Long albumId);
+    Album save(Album album);
+    void delete(Album album);
+    void addAssets(Long albumId, List<Long> assetIds);
+    void removeAssets(Long albumId, List<Long> assetIds);
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/AssetExifRepositoryPort.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/AssetExifRepositoryPort.java
@@ -1,0 +1,11 @@
+package com.jpablodrexler.photomanager.domain.port.out;
+
+import com.jpablodrexler.photomanager.domain.model.AssetExif;
+
+import java.util.Optional;
+
+public interface AssetExifRepositoryPort {
+    Optional<AssetExif> findByAssetId(Long assetId);
+    AssetExif save(AssetExif assetExif);
+    void deleteByAssetId(Long assetId);
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/AssetRepositoryPort.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/AssetRepositoryPort.java
@@ -1,0 +1,26 @@
+package com.jpablodrexler.photomanager.domain.port.out;
+
+import com.jpablodrexler.photomanager.application.dto.AssetFilter;
+import com.jpablodrexler.photomanager.application.dto.PaginatedResult;
+import com.jpablodrexler.photomanager.domain.model.Asset;
+import com.jpablodrexler.photomanager.domain.model.Folder;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AssetRepositoryPort {
+    Optional<Asset> findById(Long id);
+    Optional<Asset> findByFolderAndFileName(Folder folder, String fileName);
+    PaginatedResult<Asset> findFiltered(AssetFilter filter);
+    List<Asset> findByFolder(Folder folder);
+    List<Asset> findAll();
+    List<Asset> findAllById(List<Long> ids);
+    List<Asset> findByDeletedAtIsNull();
+    PaginatedResult<Asset> findDeleted(int page, int pageSize);
+    List<Asset> findByHash(String hash);
+    Asset save(Asset asset);
+    void delete(Asset asset);
+    long count();
+    long countDeleted();
+    boolean existsByFolderAndFileName(Folder folder, String fileName);
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/CatalogStateRepositoryPort.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/CatalogStateRepositoryPort.java
@@ -1,0 +1,15 @@
+package com.jpablodrexler.photomanager.domain.port.out;
+
+import com.jpablodrexler.photomanager.domain.model.CatalogRunState;
+
+import java.time.Instant;
+import java.util.Optional;
+
+public interface CatalogStateRepositoryPort {
+    Optional<CatalogRunState> findById(Integer id);
+    boolean tryAcquire(String instanceId, Instant now);
+    void release(String instanceId);
+    void refreshHeartbeat(String instanceId, Instant now);
+    void markCompleted(String instanceId, Instant now);
+    int releaseStaleForOtherInstances(String instanceId, Instant threshold);
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/ConvertConfigRepositoryPort.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/ConvertConfigRepositoryPort.java
@@ -1,0 +1,10 @@
+package com.jpablodrexler.photomanager.domain.port.out;
+
+import com.jpablodrexler.photomanager.domain.model.ConvertDirectoriesDefinition;
+
+import java.util.List;
+
+public interface ConvertConfigRepositoryPort {
+    List<ConvertDirectoriesDefinition> findAllOrderByOrder();
+    void replaceAll(List<ConvertDirectoriesDefinition> definitions);
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/FolderRepositoryPort.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/FolderRepositoryPort.java
@@ -1,0 +1,17 @@
+package com.jpablodrexler.photomanager.domain.port.out;
+
+import com.jpablodrexler.photomanager.domain.model.Folder;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FolderRepositoryPort {
+    Optional<Folder> findById(Long id);
+    Optional<Folder> findByPath(String path);
+    boolean existsByPath(String path);
+    List<Folder> findSubFolders(String parentPath);
+    List<Folder> findAll();
+    Folder save(Folder folder);
+    void deleteById(Long id);
+    long count();
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/HashCalculatorPort.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/HashCalculatorPort.java
@@ -1,0 +1,7 @@
+package com.jpablodrexler.photomanager.domain.port.out;
+
+import java.io.IOException;
+
+public interface HashCalculatorPort {
+    String computeHash(String filePath) throws IOException;
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/JwtTokenPort.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/JwtTokenPort.java
@@ -1,0 +1,10 @@
+package com.jpablodrexler.photomanager.domain.port.out;
+
+import java.time.Instant;
+
+public interface JwtTokenPort {
+    String generateToken(String username);
+    String extractUsername(String token);
+    boolean isTokenValid(String token);
+    Instant tokenExpiry(String token);
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/RecentTargetPathRepositoryPort.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/RecentTargetPathRepositoryPort.java
@@ -1,0 +1,10 @@
+package com.jpablodrexler.photomanager.domain.port.out;
+
+import java.util.List;
+
+public interface RecentTargetPathRepositoryPort {
+    List<String> findAllOrderByIdDesc();
+    boolean existsByPath(String path);
+    void save(String path);
+    void deleteOldestBeyond(int maxCount);
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/RefreshTokenRepositoryPort.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/RefreshTokenRepositoryPort.java
@@ -1,0 +1,12 @@
+package com.jpablodrexler.photomanager.domain.port.out;
+
+import com.jpablodrexler.photomanager.domain.model.RefreshToken;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface RefreshTokenRepositoryPort {
+    Optional<RefreshToken> findByToken(String token);
+    RefreshToken save(RefreshToken token);
+    void deleteByUserId(UUID userId);
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/SearchPresetRepositoryPort.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/SearchPresetRepositoryPort.java
@@ -1,0 +1,14 @@
+package com.jpablodrexler.photomanager.domain.port.out;
+
+import com.jpablodrexler.photomanager.domain.model.SearchPreset;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SearchPresetRepositoryPort {
+    List<SearchPreset> findByUserId(UUID userId);
+    Optional<SearchPreset> findByIdAndUserId(Long presetId, UUID userId);
+    SearchPreset save(SearchPreset preset);
+    void deleteById(Long presetId);
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/StoragePort.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/StoragePort.java
@@ -1,0 +1,26 @@
+package com.jpablodrexler.photomanager.domain.port.out;
+
+import com.jpablodrexler.photomanager.domain.enums.ImageRotation;
+import com.jpablodrexler.photomanager.domain.service.ExifMetadata;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface StoragePort {
+    List<String> listFiles(String directoryPath);
+    List<String> listSubDirectories(String directoryPath);
+    boolean directoryExists(String path);
+    void createDirectory(String path);
+    byte[] readFileBytes(String filePath) throws IOException;
+    void copyFile(String sourcePath, String destinationPath) throws IOException;
+    void moveFile(String sourcePath, String destinationPath) throws IOException;
+    void deleteFile(String filePath) throws IOException;
+    byte[] generateThumbnail(String filePath, int maxWidth, int maxHeight) throws IOException;
+    String computeHash(String filePath) throws IOException;
+    ImageRotation getImageRotation(String filePath) throws IOException;
+    long getFileSize(String filePath);
+    LocalDateTime getFileCreationDateTime(String filePath) throws IOException;
+    LocalDateTime getFileModificationDateTime(String filePath) throws IOException;
+    ExifMetadata getExifMetadata(String filePath);
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/SyncConfigRepositoryPort.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/SyncConfigRepositoryPort.java
@@ -1,0 +1,10 @@
+package com.jpablodrexler.photomanager.domain.port.out;
+
+import com.jpablodrexler.photomanager.domain.model.SyncDirectoriesDefinition;
+
+import java.util.List;
+
+public interface SyncConfigRepositoryPort {
+    List<SyncDirectoriesDefinition> findAllOrderByOrder();
+    void replaceAll(List<SyncDirectoriesDefinition> definitions);
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/ThumbnailPort.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/ThumbnailPort.java
@@ -1,0 +1,8 @@
+package com.jpablodrexler.photomanager.domain.port.out;
+
+public interface ThumbnailPort {
+    void saveThumbnail(String blobName, byte[] data);
+    byte[] loadThumbnail(String blobName);
+    void deleteThumbnail(String blobName);
+    boolean thumbnailExists(String blobName);
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/UserRepositoryPort.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/port/out/UserRepositoryPort.java
@@ -1,0 +1,15 @@
+package com.jpablodrexler.photomanager.domain.port.out;
+
+import com.jpablodrexler.photomanager.domain.model.User;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepositoryPort {
+    Optional<User> findById(UUID id);
+    Optional<User> findByUsername(String username);
+    List<User> findAll();
+    User save(User user);
+    void deleteById(UUID id);
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/entity/AlbumEntity.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/entity/AlbumEntity.java
@@ -1,0 +1,40 @@
+package com.jpablodrexler.photomanager.infrastructure.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "albums")
+@Data
+@NoArgsConstructor
+public class AlbumEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "album_id")
+    private Long albumId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String description;
+
+    @Column(nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "album_assets",
+            joinColumns = @JoinColumn(name = "album_id"),
+            inverseJoinColumns = @JoinColumn(name = "asset_id"))
+    private List<AssetEntity> assets = new ArrayList<>();
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/entity/AssetEntity.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/entity/AssetEntity.java
@@ -1,0 +1,74 @@
+package com.jpablodrexler.photomanager.infrastructure.persistence.entity;
+
+import com.jpablodrexler.photomanager.domain.enums.ImageRotation;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "assets", indexes = @Index(name = "ix_assets_folder_id", columnList = "folder_id"))
+@Data
+@NoArgsConstructor
+public class AssetEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "asset_id")
+    private Long assetId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "folder_id", nullable = false)
+    private FolderEntity folder;
+
+    @Column(name = "file_name", nullable = false)
+    private String fileName;
+
+    @Column(name = "file_size", nullable = false)
+    private long fileSize;
+
+    @Column(name = "pixel_width")
+    private Integer pixelWidth;
+
+    @Column(name = "pixel_height")
+    private Integer pixelHeight;
+
+    @Column(name = "thumbnail_pixel_width")
+    private Integer thumbnailPixelWidth;
+
+    @Column(name = "thumbnail_pixel_height")
+    private Integer thumbnailPixelHeight;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "image_rotation")
+    private ImageRotation imageRotation;
+
+    @Column(name = "thumbnail_creation_date_time", nullable = false)
+    private LocalDateTime thumbnailCreationDateTime;
+
+    @Column(name = "hash", nullable = false)
+    private String hash;
+
+    @Column(name = "file_creation_date_time")
+    private LocalDateTime fileCreationDateTime;
+
+    @Column(name = "file_modification_date_time")
+    private LocalDateTime fileModificationDateTime;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "rating", nullable = false)
+    private int rating = 0;
+
+    @Transient
+    public String getThumbnailBlobName() {
+        return assetId + ".bin";
+    }
+
+    @Transient
+    public String getFullPath() {
+        return folder != null ? folder.getPath() + "/" + fileName : fileName;
+    }
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/entity/AssetExifEntity.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/entity/AssetExifEntity.java
@@ -1,0 +1,57 @@
+package com.jpablodrexler.photomanager.infrastructure.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "asset_exif")
+@Data
+public class AssetExifEntity {
+
+    @Id
+    @Column(name = "asset_id")
+    private Long assetId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "asset_id")
+    private AssetEntity asset;
+
+    @Column(name = "camera_make")
+    private String cameraMake;
+
+    @Column(name = "camera_model")
+    private String cameraModel;
+
+    @Column(name = "lens_model")
+    private String lensModel;
+
+    @Column(name = "exposure_time")
+    private String exposureTime;
+
+    @Column(name = "f_number")
+    private Double fNumber;
+
+    @Column(name = "iso_speed")
+    private Integer isoSpeed;
+
+    @Column(name = "focal_length")
+    private Double focalLength;
+
+    @Column(name = "date_taken")
+    private LocalDateTime dateTaken;
+
+    @Column(name = "width_pixels")
+    private Integer widthPixels;
+
+    @Column(name = "height_pixels")
+    private Integer heightPixels;
+
+    @Column(name = "gps_latitude")
+    private Double gpsLatitude;
+
+    @Column(name = "gps_longitude")
+    private Double gpsLongitude;
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/entity/FolderEntity.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/entity/FolderEntity.java
@@ -1,0 +1,39 @@
+package com.jpablodrexler.photomanager.infrastructure.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Entity
+@Table(name = "folders")
+@Data
+@NoArgsConstructor
+public class FolderEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "folder_id")
+    private Long folderId;
+
+    @Column(name = "path", nullable = false)
+    private String path;
+
+    @Transient
+    public String getName() {
+        if (path == null || path.isBlank())
+            return "";
+        Path p = Paths.get(path);
+        return p.getFileName() != null ? p.getFileName().toString() : path;
+    }
+
+    @Transient
+    public String getParentPath() {
+        if (path == null || path.isBlank())
+            return null;
+        Path p = Paths.get(path);
+        return p.getParent() != null ? p.getParent().toString() : null;
+    }
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/entity/RefreshTokenEntity.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/entity/RefreshTokenEntity.java
@@ -1,0 +1,35 @@
+package com.jpablodrexler.photomanager.infrastructure.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "refresh_tokens")
+@Data
+@NoArgsConstructor
+public class RefreshTokenEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "token_id")
+    private Long tokenId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private Instant expiresAt;
+
+    @Column(nullable = false)
+    private boolean revoked;
+
+    @Column(nullable = false, updatable = false)
+    private Instant issuedAt;
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/entity/SearchPresetEntity.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/entity/SearchPresetEntity.java
@@ -1,0 +1,32 @@
+package com.jpablodrexler.photomanager.infrastructure.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "search_presets")
+@Data
+@NoArgsConstructor
+public class SearchPresetEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "preset_id")
+    private Long presetId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "filter_json", nullable = false, columnDefinition = "TEXT")
+    private String filterJson;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/entity/UserEntity.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/entity/UserEntity.java
@@ -1,0 +1,32 @@
+package com.jpablodrexler.photomanager.infrastructure.persistence.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "users")
+@Data
+@NoArgsConstructor
+public class UserEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id")
+    private UUID id;
+
+    @Column(name = "username", nullable = false, unique = true, length = 50)
+    private String username;
+
+    @Column(name = "password_hash", nullable = false)
+    private String passwordHash;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "role", nullable = false, length = 20)
+    private String role = "USER";
+}


### PR DESCRIPTION
Introduces two new application layers for migrating the WPF desktop app:

backend/ — Spring Boot 3.4 REST API with Java 21
- Domain entities (Asset, Folder, SyncAssetsDirectoriesDefinition, ConvertAssetsDirectoriesDefinition, RecentTargetPath)
- Enums matching the original C# enumerations (ImageRotation, SortCriteria, WallpaperStyle, ReasonEnum)
- Spring Data JPA repositories with SQLite via Flyway migrations
- Service interfaces and infrastructure implementations for catalog, sync, convert, move, duplicate detection
- REST controllers for assets, folders, sync, and convert with Server-Sent Events for long-running operations
- StorageServiceImpl with EXIF rotation support (Apache Commons Imaging) and thumbnail generation
- application.yml configured for SQLite persistence and async task execution

frontend/ — Angular 19 SPA with Angular Material
- Standalone components with lazy-loaded routes (gallery, sync, convert, duplicates)
- Core services (AssetService, FolderService, SyncService, ConvertService) calling the backend API
- GalleryComponent with thumbnail grid, image viewer, pagination, sorting, and real-time catalog SSE
- FolderNavComponent using Angular CDK FlatTreeControl
- SyncComponent and ConvertComponent with configure → run → results flow using SSE
- DuplicatesComponent for hash-based duplicate detection and cleanup
- ThumbnailComponent (shared) and FileSizePipe
- Proxy config forwarding /api calls to localhost:8080

https://claude.ai/code/session_01XJXdFufgRiTV6gC39MMWPL