### PR TITLE
Add PWA installation instructions to web README

### DIFF
--- a/JPPhotoManagerWeb/README.md
+++ b/JPPhotoManagerWeb/README.md
@@ -881,6 +881,48 @@ UID=$(id -u) GID=$(id -g) docker compose up
 
 ---
 
+## Installing as a Progressive Web App (PWA)
+
+JP Photo Manager ships as a PWA: it can be installed as a standalone desktop or mobile app directly from the browser, with offline thumbnail caching and background sync for rating changes.
+
+> **Important:** The PWA service worker only activates in a **production build**. Install prompts will not appear when running the Angular dev server (`npm start`). Use the Docker Compose setup or a production build served by nginx.
+
+### Prerequisites
+
+The app must be running via Docker Compose (see [Running with Docker Compose](#running-with-docker-compose)):
+
+```bash
+cd JPPhotoManagerWeb
+cp .env.example .env
+# Edit .env: set HOST_IMAGE_DIR and JWT_SECRET at minimum
+docker compose up --build
+```
+
+Then open `http://localhost` in a supported browser.
+
+### Installing from the browser
+
+| Browser | How to install |
+|---|---|
+| **Chrome / Edge** | An install icon (⊕) appears in the address bar — click it, then **Install** |
+| **Chrome (menu)** | ⋮ menu → **Save and share** → **Install JP Photo Manager** |
+| **Edge (menu)** | ··· menu → **Apps** → **Install this site as an app** |
+| **Safari (macOS)** | **File** → **Add to Dock** (requires macOS Sonoma or later) |
+| **Safari (iOS)** | Share sheet → **Add to Home Screen** |
+| **Firefox** | Not supported — Firefox does not implement PWA installation |
+
+Once installed the app opens in its own window (no browser chrome) under the name **JP Photo Manager** (short name: **PhotoMgr**).
+
+### PWA capabilities
+
+| Capability | Detail |
+|---|---|
+| **Offline thumbnail cache** | Previously viewed thumbnails are served from the service-worker cache when the network is unavailable (cache-first strategy configured in `ngsw-config.json`) |
+| **Background sync for ratings** | Star-rating changes made while offline are queued in IndexedDB via `BackgroundSyncService` and replayed automatically when connectivity is restored; a snackbar notification confirms the replay |
+| **App icons** | Full icon set from 72×72 to 512×512 pixels, suitable for home screens and taskbars |
+
+---
+
 ## CI/CD
 
 Two GitHub Actions workflows are defined in `.github/workflows/`:


### PR DESCRIPTION
## Summary

- Adds a new **"Installing as a Progressive Web App (PWA)"** section to `JPPhotoManagerWeb/README.md`
- Documents the production-build requirement (service worker does not activate in dev mode)
- Provides browser-specific install steps for Chrome, Edge, Safari (macOS and iOS), and notes Firefox is unsupported
- Summarises PWA capabilities: offline thumbnail cache, background sync for ratings, and app icons

## Test plan

- [ ] Read through the new section and verify all steps are accurate against the implementation in commit `8e3b9b1` (ngsw-config.json, manifest.webmanifest, BackgroundSyncService)
- [ ] Confirm the section renders correctly in GitHub's Markdown preview
- [ ] Start the app via `docker compose up --build` and verify the install prompt appears in Chrome/Edge at `http://localhost`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZhjjnUkvDGKbkeQJXAa3N

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZhjjnUkvDGKbkeQJXAa3N)_