### PR TITLE
Update root README web application section to match current stack

### DIFF
--- a/JPPhotoManagerWeb/README.md
+++ b/JPPhotoManagerWeb/README.md
@@ -11,11 +11,14 @@ A web rewrite of the JP Photo Manager desktop application. It replaces the origi
 - **Thumbnail grid** — paginated 200×150 thumbnail cards for all images in the selected folder.
 - **Full-screen viewer** — double-click any thumbnail to open the original at full resolution with zoom controls; press the grid icon to return.
 - **Folder tree navigation** — collapsible sidebar showing the catalogued folder hierarchy; click any folder to load its assets.
-- **Search and filter** — filter assets by file name, date range, and minimum star rating.
+- **Timeline view** — browse assets grouped by date instead of a flat grid.
+- **Search and filter** — filter assets by file name, date range, minimum star rating, and tags.
 - **Sort** — sort by file name, creation date, modification date, file size, or rating.
-- **Star rating** — rate each image 0–10 stars directly from the thumbnail grid or viewer.
+- **Star rating** — rate each image 0–5 stars directly from the thumbnail grid or viewer.
+- **Tagging** — add or remove free-form tags on one or many assets at once, with autocomplete suggestions.
 - **EXIF metadata panel** — view camera make and model, ISO, aperture, exposure time, and focal length extracted from image files.
-- **Move / copy** — select one or more images and move or copy them to another catalogued folder.
+- **Move / copy / rename** — select one or more images and move, copy, or rename them.
+- **Crop** — crop and save an asset in place.
 - **Drag-and-drop upload** — drag files from the desktop and drop them onto the gallery to upload them.
 - **Download** — download a selection of images as a ZIP archive (up to the configured `max-download-assets` limit).
 - **Add to album** — add selected images to an existing album or create a new one on the spot.
@@ -55,6 +58,15 @@ A web rewrite of the JP Photo Manager desktop application. It replaces the origi
 
 - At-a-glance statistics: total catalogued folders, total assets, combined file size, and average star rating across the library.
 
+### Analytics
+
+- Storage breakdown per folder, file-format distribution, photos-per-month trend, and star-rating distribution across the catalog (`/analytics` page).
+
+### Audio Playback
+
+- Stream audio assets (e.g. MP3) directly from the catalog with playback controls.
+- Play `.m3u`/`.pls` playlist files as a queue, resolving each referenced track back to a catalogued asset.
+
 ### Image Cataloging
 
 - The backend automatically scans all configured root folders on startup and then re-scans after a configurable cooldown (default: 2 minutes).
@@ -83,12 +95,13 @@ A web rewrite of the JP Photo Manager desktop application. It replaces the origi
 ```mermaid
 graph TB
     subgraph browser["Browser"]
-        Angular["Angular 19 SPA\nGallery · Albums · Sync · Convert · Duplicates · Recycle Bin"]
+        Angular["Angular 19 SPA\nGallery · Albums · Sync · Convert · Duplicates · Recycle Bin\nAnalytics · Audio Player"]
     end
 
     subgraph backend["Backend — port 8080"]
         SpringBoot["Spring Boot 3 REST API\n(Java 21)"]
         KPL["KafkaProgressListener\n(sse-broadcaster group)"]
+        RLF["RateLimitFilter\n(Bucket4j)"]
     end
 
     subgraph messaging["Messaging — port 9092"]
@@ -97,15 +110,21 @@ graph TB
 
     subgraph persistence["Persistence"]
         PG[("PostgreSQL 18\nphotomanager")]
+        Mongo[("MongoDB 8\nasset_audit_log")]
+        Redis[("Redis 7\nthumbnail + query caches\nrefresh tokens · rate limits")]
         FS[("File System\nimages + thumbnails")]
     end
 
     Angular -->|"HTTP REST (JSON)"| SpringBoot
     Angular -->|"SSE (EventSource)"| SpringBoot
     SpringBoot -->|"JDBC / JPA (Hibernate)"| PG
+    SpringBoot -->|"audit log writes"| Mongo
+    SpringBoot -->|"cache/session ops"| Redis
+    RLF -->|"token buckets"| Redis
     SpringBoot -->|"File I/O"| FS
-    SpringBoot -->|"publish progress events"| Kafka
+    SpringBoot -->|"publish progress + domain events"| Kafka
     Kafka -->|"consume progress events"| KPL
+    Kafka -->|"consume domain events"| Mongo
     KPL -->|"SseEmitter.send()"| SpringBoot
 ```
 
@@ -249,14 +268,31 @@ erDiagram
         timestamp started_at
         timestamp last_heartbeat_at
     }
+    tags {
+        serial tag_id PK
+        varchar name UK
+    }
+    asset_tags {
+        bigint asset_id FK
+        bigint tag_id FK
+    }
+    user_preferences {
+        uuid user_id PK_FK
+        varchar theme_mode
+        timestamptz updated_at
+    }
 
     folders ||--o{ assets : "contains"
     assets ||--o| asset_exif : "has EXIF"
     users ||--o{ albums : "owns"
     users ||--o{ refresh_tokens : "has"
     users ||--o{ search_presets : "owns"
+    users ||--o| user_preferences : "has"
     albums }o--o{ assets : "album_assets"
+    assets }o--o{ tags : "asset_tags"
 ```
+
+The `asset_audit_log` collection (user-action history) lives in MongoDB, not PostgreSQL, so it isn't part of this diagram — see [Persistence](#persistence).
 
 ### Frontend Component Hierarchy
 
@@ -275,12 +311,16 @@ graph TD
     App --> Albums["AlbumsComponent\n/albums"]
     App --> RecycleBin["RecycleBinComponent\n/recycle-bin"]
     App --> UserAdmin["UserAdminComponent\n/admin/users"]
+    App --> Analytics["AnalyticsComponent\n/analytics"]
 
     Gallery --> FolderNav["FolderNavComponent\n(folder tree sidebar)"]
     Gallery --> Thumbnail["ThumbnailComponent\n(shared card)"]
+    Gallery --> AudioPlayer["AudioPlayerComponent\n(playback controls)"]
     Albums --> AlbumDetail["AlbumDetailComponent\n/albums/:id"]
     AlbumDetail --> Thumbnail
 ```
+
+The default route (`/`) redirects to `/home`.
 
 ### Project Structure
 
@@ -315,7 +355,10 @@ JPPhotoManagerWeb/
 │   ├── prometheus.yaml        # `prometheus`→ Service + Deployment
 │   ├── grafana.yaml           # `grafana`   → Service + Deployment + PVC
 │   └── ingress.yaml           # Routes external traffic to `frontend`
-└── kustomization.yaml     # Entry point: `kubectl apply -k .`
+├── kustomization.yaml     # Entry point: `kubectl apply -k .`
+├── build-and-deploy-k8s.sh # Builds images and applies the Kubernetes stack end-to-end
+├── port-forward-k8s.sh    # Starts background port-forwards for Grafana/PostgreSQL/MongoDB/Kafka
+└── migrate-db.sh          # One-time migration of a host PostgreSQL catalog into Docker Compose
 ```
 
 ---
@@ -330,17 +373,27 @@ JPPhotoManagerWeb/
 | Spring Boot | 3.4.4 |
 | Spring Web (REST + SSE) | managed by Spring Boot |
 | Spring Data JPA | managed by Spring Boot |
+| Spring Data MongoDB | managed by Spring Boot |
+| Spring Data Redis | managed by Spring Boot |
 | Spring Batch | managed by Spring Boot |
 | Spring Kafka | managed by Spring Boot |
+| Spring Security | managed by Spring Boot |
 | Spring Validation | managed by Spring Boot |
-| Spring Actuator | managed by Spring Boot |
+| Spring Actuator + Micrometer (Prometheus registry) | managed by Spring Boot |
 | Hibernate (PostgreSQL dialect) | managed by Spring Boot |
 | PostgreSQL JDBC | managed by Spring Boot |
 | Flyway + Flyway PostgreSQL extension | managed by Spring Boot |
 | Apache Kafka (KRaft) | 3.9.0 (via Docker) |
+| Redis | 7 (via Docker) |
+| MongoDB | 8 (via Docker) |
+| JJWT (JWT signing/verification) | 0.12.6 |
+| Bucket4j + Bucket4j Redis (rate limiting) | 8.10.1 |
+| springdoc-openapi (Swagger UI) | 2.8.9 |
 | Lombok | 1.18.46 |
 | MapStruct | 1.6.3 |
 | Apache Commons Imaging | 1.0-alpha3 |
+| jaudiotagger (audio metadata) | 3.0.1 |
+| logstash-logback-encoder (JSON logging) | 8.0 |
 | GitHub API client | 1.321 |
 | JUnit 5 + Mockito + AssertJ | managed by Spring Boot |
 | Testcontainers (PostgreSQL) | managed by Spring Boot |
@@ -348,30 +401,48 @@ JPPhotoManagerWeb/
 
 ### Internal architecture
 
-The backend follows a clean architecture with strict layering:
+The backend follows the same Hexagonal (Ports and Adapters) layout described in [Backend Hexagonal Architecture](#backend-hexagonal-architecture) above:
 
 ```
-api/                     → REST controllers and request/response DTOs
-application/usecase/     → Use-case implementations (one class per port/in interface)
-application/dto/         → Application DTOs: progress messages (CatalogProgressMessage,
-                           SyncProgressMessage, ConvertProgressMessage) and result types
+application/
+  dto/                   → Application DTOs: progress messages (CatalogProgressMessage,
+                           SyncProgressMessage, ConvertProgressMessage), AssetFilter, PaginatedResult…
+  usecase/                → One implementation class per port/in interface, grouped by subdomain:
+                           album, analytics, asset, audit, auth, catalog, convert, folder, home,
+                           preference, recycle, search, sync, tag, user
 domain/
-  model/                 → Pure domain POJOs (Asset, Folder, …)
+  model/                 → Pure domain POJOs (Asset, Folder, User, AuditEvent, …)
   enums/                 → ImageRotation, SortCriteria, WallpaperStyle, ReasonEnum
-  port/in/               → Use-case interfaces
+  port/in/               → Use-case interfaces, grouped the same way as usecase/
   port/out/              → Repository and service port interfaces
 infrastructure/
-  web/                   → REST controllers, HTTP DTOs, MapStruct mappers
-  persistence/           → Spring Data JPA adapters (XxxRepositoryImpl, @Entity classes)
-  service/               → Service adapters: StorageServiceAdapter, ThumbnailStorageService,
+  web/
+    controller/          → REST controllers (AssetController, AlbumController, AuthController, …)
+    dto/                  → HTTP request/response DTOs
+    mapper/               → MapStruct HTTP DTO ↔ domain mappers
+    filter/               → JwtAuthenticationFilter, RateLimitFilter (Bucket4j, backed by Redis)
+    exception/            → GlobalExceptionHandler
+  persistence/
+    entity/               → @Entity JPA classes
+    jpa/                  → Spring Data JPA repositories
+    adapter/              → Repository port implementations (XxxRepositoryImpl)
+    mapper/                → MapStruct entity ↔ domain mappers
+    mongo/                 → MongoAuditLogRepository (`asset_audit_log` collection)
+    document/              → AuditLogDocument (Mongo document)
+    redis/                 → RedisRefreshTokenStore (refresh-token mirror)
+  service/                → Service adapters: StorageServiceAdapter, ThumbnailStorageServiceAdapter,
+                           JwtTokenServiceAdapter, RefreshTokenServiceAdapter, CatalogScheduler,
+                           AssetSearchCacheServiceAdapter (Redis query-cache eviction),
                            KafkaProgressRegistry (runId → SseEmitter + CompletableFuture map)
-  kafka/                 → KafkaProgressListener — @KafkaListener on all three progress topics;
-                           routes messages to SseEmitter via KafkaProgressRegistry
-  batch/                 → Spring Batch job config and item writers/listeners (catalog pipeline)
-  config/                → AppConfig (CORS, async executor), KafkaTopicConfig (topic declarations)
+  kafka/                  → KafkaProgressListener (SSE bridge), AuditLogKafkaListener,
+                           AssetSearchCacheInvalidationListener, and the Batch pipeline's
+                           hash/thumbnail/EXIF item processors
+  batch/                  → Spring Batch job config and item readers/writers/listeners (catalog pipeline)
+  health/                 → Custom Actuator health indicators (database, thumbnail storage, geocoding)
+  config/                 → AppConfig, SecurityConfig, MongoConfig, KafkaTopicConfig, …
 ```
 
-**Dependency flow:** `api` → `application` → `domain` ← `infrastructure`
+**Dependency flow:** `infrastructure/web` → `application/usecase` → `domain` ← `infrastructure/persistence` | `infrastructure/service`
 
 Controllers are thin: they delegate immediately to use-case interfaces and never touch repositories or service adapters directly.
 
@@ -386,27 +457,84 @@ Controllers are thin: they delegate immediately to use-case interfaces and never
 | `MoveAssetsUseCase` | Copies or moves files on disk and updates the corresponding DB record. |
 | `KafkaProgressRegistry` | Thread-safe `ConcurrentHashMap` keyed by `runId`; holds the `SseEmitter` registered by the controller and the `CompletableFuture<Void>` registered by the catalog use case. Bridges Kafka consumer callbacks back to waiting HTTP connections. |
 | `KafkaProgressListener` | `@KafkaListener` on `job.catalog.progress`, `job.sync.progress`, and `job.convert.progress` (consumer group `sse-broadcaster`). Routes each message to the `SseEmitter` for its `runId`; calls `registry.complete(runId)` on `done=true`. |
-| `StorageService` | File I/O, thumbnail generation, EXIF rotation reading (Apache Commons Imaging), SHA-256 hashing. |
-| `ThumbnailStorageService` | Stores and retrieves thumbnails as `{assetId}.bin` files under the configured thumbnails directory. |
+| `StorageServiceAdapter` | File I/O, thumbnail generation, EXIF rotation reading (Apache Commons Imaging), SHA-256 hashing. |
+| `ThumbnailStorageServiceAdapter` | Stores and retrieves thumbnails as `{assetId}.bin` files under the configured thumbnails directory, fronted by a Redis L2 cache with a 24-hour TTL. |
+| `JwtTokenServiceAdapter` / `RefreshTokenServiceAdapter` | Issue and validate the JWT access token and the longer-lived refresh token; refresh tokens are dual-written to PostgreSQL and mirrored into Redis (`RedisRefreshTokenStore`). |
+| `RateLimitFilter` | Servlet filter backed by Bucket4j + Redis; throttles requests per client IP (or the trusted `X-Forwarded-For` value behind a reverse proxy). |
+| `AssetSearchCacheServiceAdapter` | Evicts the Redis-backed `assets`/`tags` query caches per folder via cursor-based `SCAN`/`DEL`, triggered by `AssetSearchCacheInvalidationListener` (Kafka) and directly by the tag-mutation use cases. |
+| `AuditLogKafkaListener` | Consumes `asset.cataloged`/`asset.deleted`/`job.*.progress` events and appends them to the MongoDB `asset_audit_log` collection; tag/rating/view/download actions are logged directly by their use cases. |
 
 ### Persistence
 
-- **Database:** PostgreSQL 18
-- **Schema migrations:** Flyway, scripts in `src/main/resources/db/migration/`
-- **ORM:** Spring Data JPA with the Hibernate PostgreSQL dialect
-- **Connection:** configured via environment variables `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USERNAME`, `POSTGRES_PASSWORD` (defaults: `localhost`, `5432`, `photomanager`, `postgres`, `postgres`)
+- **Primary database:** PostgreSQL 18 — assets, folders, users, albums, refresh tokens, search presets, sync/convert configuration, and the `catalog_run_state` distributed lock.
+  - **Schema migrations:** Flyway, scripts in `src/main/resources/db/migration/`
+  - **ORM:** Spring Data JPA with the Hibernate PostgreSQL dialect
+  - **Connection:** configured via `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USERNAME`, `POSTGRES_PASSWORD` (defaults: `localhost`, `5432`, `photomanager`, `postgres`, `postgres`)
+- **MongoDB:** append-only store for the `asset_audit_log` collection (user-action history), populated by `AuditLogKafkaListener` and direct `AuditLogRepository.log(...)` calls. Configured via `MONGO_URI`.
+- **Redis:** thumbnail L2 cache, query-result caches (`assets`, `tags`, `home-stats`, `sub-folders`, `asset-exif`), the refresh-token mirror, and the Bucket4j rate-limit counters. Every Redis call fails open — a Redis outage degrades to always querying PostgreSQL/disk rather than failing the request. Configured via `REDIS_HOST`, `REDIS_PORT`.
 
 ### REST API
 
+All endpoints below except the three under **Auth** marked *Public* require the `jwt` cookie; endpoints under **Admin** additionally require the `ADMIN` role.
+
+**Auth**
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `POST` | `/api/auth/login` | Public | Authenticate; sets `jwt` + `refreshToken` HttpOnly cookies |
+| `POST` | `/api/auth/refresh` | Public | Rotate the JWT using the refresh-token cookie |
+| `POST` | `/api/auth/logout` | Public | Clears both cookies server-side |
+| `GET` | `/api/auth/me` | Required | Current authenticated user |
+
+**Assets**
+
 | Method | Path | Description |
 |---|---|---|
-| `GET` | `/api/assets` | Paginated asset list for a folder (`folderPath`, `page`, `sort`) |
+| `GET` | `/api/assets` | Paginated asset list for a folder (`folderPath`, `page`, `sort`, `search`, `dateFrom`, `dateTo`, `minRating`, `tags`) |
+| `GET` | `/api/assets/timeline` | Assets grouped by date (timeline view) |
 | `GET` | `/api/assets/{id}/thumbnail` | 200×150 JPEG thumbnail |
 | `GET` | `/api/assets/{id}/image` | Full-size original image |
-| `GET` | `/api/assets/catalog` | SSE stream — catalog progress events |
-| `GET` | `/api/assets/duplicates` | Grouped duplicate assets |
+| `GET` | `/api/assets/{id}/exif` | EXIF metadata for an asset |
+| `GET` | `/api/assets/catalog` | SSE stream — run catalog and stream progress |
+| `GET` | `/api/assets/catalog/observe` | SSE stream — observe an already-running catalog run |
 | `POST` | `/api/assets/move` | Move or copy assets to a destination folder |
+| `POST` | `/api/assets/rename` | Rename assets |
+| `POST` | `/api/assets/download` | Download assets as a ZIP archive (up to `max-download-assets`) |
+| `PATCH` | `/api/assets/{id}/rating` | Rate an asset (0–5; 0 clears the rating) |
 | `DELETE` | `/api/assets` | Remove assets from catalog (optionally delete files) |
+| `GET` | `/api/assets/duplicates` | Grouped duplicate assets |
+| `POST` | `/api/assets/upload` | Upload a file into a folder |
+| `GET` | `/api/assets/upload/{assetId}/observe` | SSE stream — observe post-upload processing |
+| `POST` | `/api/assets/{id}/reprocess` | Regenerate an asset's thumbnail/hash/EXIF |
+| `POST` | `/api/assets/{id}/crop` | Crop and save an asset |
+| `POST` | `/api/assets/{id}/tags` | Add a tag to a single asset |
+| `DELETE` | `/api/assets/{id}/tags` | Remove a tag from a single asset |
+| `POST` | `/api/assets/tags/bulk` | Add a tag to multiple assets at once |
+| `DELETE` | `/api/assets/tags/bulk` | Remove a tag from multiple assets at once |
+
+**Tags, Albums, Search Presets, Recycle Bin**
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/tags` | Tag suggestions matching a prefix (`q`) |
+| `GET` | `/api/albums` | List all albums |
+| `POST` | `/api/albums` | Create an album |
+| `GET` | `/api/albums/{id}` | Paginated album assets |
+| `PUT` | `/api/albums/{id}` | Rename/update an album |
+| `DELETE` | `/api/albums/{id}` | Delete an album |
+| `POST` | `/api/albums/{id}/assets` | Add assets to an album |
+| `DELETE` | `/api/albums/{id}/assets` | Remove assets from an album |
+| `GET` | `/api/search-presets` | List saved search presets |
+| `POST` | `/api/search-presets` | Save the current filters as a preset |
+| `DELETE` | `/api/search-presets/{id}` | Delete a preset |
+| `GET` | `/api/recycle-bin` | Paginated soft-deleted assets |
+| `POST` | `/api/recycle-bin/restore` | Restore assets from the recycle bin |
+| `DELETE` | `/api/recycle-bin` | Purge specific assets (or all, with an empty body) permanently |
+
+**Folders, Sync, Convert**
+
+| Method | Path | Description |
+|---|---|---|
 | `GET` | `/api/folders` | Catalogued folders, optionally filtered by `parentPath` |
 | `GET` | `/api/folders/drives` | Available filesystem roots |
 | `GET` | `/api/folders/initial` | Configured initial folder |
@@ -418,6 +546,29 @@ Controllers are thin: they delegate immediately to use-case interfaces and never
 | `PUT` | `/api/convert/configuration` | Save convert directory pairs |
 | `GET` | `/api/convert/run` | SSE stream — run conversion and stream status |
 
+**Media, Home/Analytics, Preferences, Audit Log**
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/assets/{id}/stream` | Stream an audio asset |
+| `GET` | `/api/audio/playlist/{id}` | Resolve a playlist asset (`.m3u`/`.pls`) to its track list |
+| `GET` | `/api/home/stats` | Dashboard statistics (total assets, folders, size, average rating) |
+| `GET` | `/api/analytics` | Storage-per-folder, format distribution, photos-per-month, rating distribution |
+| `GET` | `/api/preferences` | Current user's UI preference (theme mode) |
+| `PUT` | `/api/preferences` | Save the current user's UI preference |
+| `GET` | `/api/audit-log` | Paginated audit trail (`userId`, `entityId`, `from`, `to`, `page`, `size`); non-admins are scoped to their own `userId` |
+
+**Admin** (requires the `ADMIN` role)
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/admin/users` | List all users |
+| `POST` | `/api/admin/users` | Create a user |
+| `PATCH` | `/api/admin/users/{id}/password` | Change a user's password |
+| `DELETE` | `/api/admin/users/{id}` | Delete a user |
+
+The full interactive contract is served by Swagger UI (`/swagger-ui.html`) — see [Running the backend](#running-the-backend) below.
+
 ### Configuration
 
 All settings live in `src/main/resources/application.yml`:
@@ -427,28 +578,46 @@ All settings live in `src/main/resources/application.yml`:
 | `server.port` | `8080` | HTTP server port |
 | `photomanager.initial-directory` | `~/Pictures` | Starting folder shown in the UI |
 | `photomanager.root-catalog-folders` | `~/Pictures` | Semicolon-separated folder roots to catalog |
-| `photomanager.catalog-batch-size` | `1000` | Files processed per catalog pass |
+| `photomanager.catalog-batch-size` | `1000` | Files processed per catalog pass (also the heartbeat interval) |
 | `photomanager.catalog-cooldown-minutes` | `2` | Minimum minutes between catalog runs |
+| `photomanager.catalog-timeout` | `60` | Minutes without a heartbeat before a catalog run is considered stale |
 | `photomanager.thumbnails-directory` | `~/.photomanager/thumbnails` | Thumbnail storage path — overridden by `THUMBNAILS_DIR` env var |
+| `photomanager.thumbnail-cache.enabled` | `true` | Enables the Redis L2 thumbnail cache — overridden by `THUMBNAIL_CACHE_ENABLED` |
+| `photomanager.thumbnail-cache.ttl-seconds` | `86400` | TTL for cached thumbnail bytes — overridden by `THUMBNAIL_CACHE_TTL_SECONDS` |
+| `photomanager.jwt-secret` | *(empty — must be set)* | HS256 signing secret (≥ 32 bytes); see [Authentication](#authentication) |
+| `photomanager.jwt-expiry-hours` | `24` | JWT access-token validity in hours |
+| `photomanager.refresh-token-expiry-days` | `30` | Refresh-token validity in days |
+| `photomanager.cors-allowed-origins` | `http://localhost:4200` | Allowed CORS origin(s), e.g. the Angular dev server |
+| `photomanager.max-download-assets` | `500` | Max assets allowed in a single ZIP download request |
+| `photomanager.trusted-proxy-ips` | *(empty)* | Comma-separated reverse-proxy IPs whose `X-Forwarded-For` header is trusted for rate limiting |
+| `photomanager.recycle-bin-retention-days` | `30` | Days a soft-deleted asset stays in the recycle bin |
+| `photomanager.geocoding-base-url` | `https://nominatim.openstreetmap.org` | Reverse-geocoding endpoint polled by the `geocoding` Actuator health indicator |
 | `POSTGRES_HOST` | `localhost` | PostgreSQL host |
 | `POSTGRES_PORT` | `5432` | PostgreSQL port |
 | `POSTGRES_DB` | `photomanager` | Database name |
 | `POSTGRES_USERNAME` | `postgres` | Database user |
 | `POSTGRES_PASSWORD` | `postgres` | Database password |
+| `REDIS_HOST` | `localhost` | Redis host |
+| `REDIS_PORT` | `6379` | Redis port |
+| `MONGO_URI` | `mongodb://localhost:27017/photomanager` | MongoDB connection URI (`asset_audit_log` collection) |
 | `CATALOG_DIR` | *(unset — falls back to `~/Pictures`)* | Overrides `initial-directory` and `root-catalog-folders` |
 | `THUMBNAILS_DIR` | *(unset — falls back to `~/.photomanager/thumbnails`)* | Overrides `thumbnails-directory` |
 | `KAFKA_BOOTSTRAP` | `localhost:9092` | Kafka bootstrap server address; set to `kafka:9092` in Docker Compose |
 
 ### Running the backend
 
-**Prerequisites:** Java 21, Maven 3.9+, PostgreSQL 18 + Apache Kafka (or Docker)
+**Prerequisites:** Java 21, Maven 3.9+, and Docker to run PostgreSQL 18, MongoDB, Redis, and Apache Kafka (all four are required — the app also uses MongoDB for the audit log and Redis for caching/rate limiting)
 
-Start a local PostgreSQL instance and Kafka broker if you don't have them:
+Start local PostgreSQL, MongoDB, Redis, and Kafka instances if you don't have them:
 ```bash
 docker run -d --name photomanager-db \
   -e POSTGRES_PASSWORD=postgres \
   -e POSTGRES_DB=photomanager \
   -p 5432:5432 postgres:18
+
+docker run -d --name photomanager-mongo -p 27017:27017 mongo:8
+
+docker run -d --name photomanager-redis -p 6379:6379 redis:7-alpine
 
 docker run -d --name photomanager-kafka \
   -p 9092:9092 -p 9094:9094 \
@@ -463,6 +632,8 @@ docker run -d --name photomanager-kafka \
   -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 \
   apache/kafka:3.9.0
 ```
+
+You'll also need `photomanager.jwt-secret` set — see [Setup (local development)](#setup-local-development) under Authentication.
 
 ```bash
 cd JPPhotoManagerWeb/backend
@@ -513,41 +684,62 @@ Tests use the `test` Spring profile (`src/test/resources/application-test.yml`).
 | Angular | 19 |
 | Angular Material | 19 |
 | Angular CDK | 19 |
+| Angular Service Worker (PWA) | 19 |
 | TypeScript | 5.6 |
 | RxJS | 7.8 |
+| ngx-charts | 24.0.0-alpha.1 |
+| idb (IndexedDB wrapper, background sync) | 8.0.3 |
 | Node.js (build/dev) | 22 |
-| Karma + Jasmine | 6.4 / 5.4 |
+| Cypress (component + e2e tests) | 15 |
+| ESLint (`@angular-eslint`, `typescript-eslint`) | 9 |
 
 ### Application structure
 
 ```
 src/app/
-  app.component.ts/html/scss   → Shell with top navigation bar
-  app.routes.ts                → Lazy routes: /gallery, /sync, /convert, /duplicates
-  app.config.ts                → ApplicationConfig (HttpClient, Router, Animations)
+  app.component.ts/html/scss   → Shell with top navigation bar (shown only when logged in)
+  app.routes.ts                → Lazy routes: /home, /gallery, /sync, /convert, /duplicates,
+                                 /albums, /albums/:id, /recycle-bin, /admin/users, /analytics
+  app.config.ts                → ApplicationConfig (HttpClient + interceptor, Router, Animations)
   core/
     models/                    → TypeScript interfaces (Asset, Folder, PaginatedData, …)
     services/                  → Angular services wrapping the backend REST API
+    guards/                    → auth.guard.ts — redirects unauthenticated users to /login
+    interceptors/              → auth.interceptor.ts — handles 401 → redirect to /login
   features/
+    auth/login/                → LoginComponent (/login)
+    home/                      → HomeComponent (/home) — dashboard with stats
     gallery/                   → Thumbnail grid + full-size image viewer
     folder-nav/                → Folder tree (Angular CDK FlatTreeControl)
     sync/                      → Sync configuration and execution
     convert/                   → Convert configuration and execution
     duplicates/                → Duplicate detection and cleanup
+    albums/                    → AlbumsComponent + AlbumDetailComponent
+    recycle-bin/                → Restore/purge soft-deleted assets
+    analytics/                  → Storage/format/rating charts (ngx-charts)
+    audio-player/                → Playback controls for streamed audio assets
+    admin/users/                → UserAdminComponent (/admin/users) — add/change password/delete users
   shared/
     components/thumbnail/      → Reusable thumbnail card component
     pipes/file-size.pipe.ts    → Human-readable file size formatting
 ```
 
-All components are **standalone** (no NgModules). Routes are lazy-loaded:
+All components are **standalone** (no NgModules). Routes are lazy-loaded and, except `/login`, protected by `authGuard`:
 
 | Path | Feature | Description |
 |---|---|---|
-| `/` | — | Redirects to `/gallery` |
+| `/` | — | Redirects to `/home` |
+| `/login` | Login | Public login form |
+| `/home` | Home | Dashboard with catalog statistics |
 | `/gallery` | Gallery | Paginated thumbnail grid and full-size viewer |
 | `/sync` | Sync | Configure and run directory sync |
 | `/convert` | Convert | Configure and run PNG→JPEG conversion |
 | `/duplicates` | Duplicates | Find and remove duplicate images |
+| `/albums` | Albums | List, create, rename, and delete albums |
+| `/albums/:id` | Album detail | Paginated asset grid within an album |
+| `/recycle-bin` | Recycle Bin | Restore or purge soft-deleted assets |
+| `/admin/users` | User Administration | Add, change password, delete users |
+| `/analytics` | Analytics | Storage, format, monthly, and rating charts |
 
 ### Gallery modes
 
@@ -649,12 +841,28 @@ Output goes to `dist/jp-photo-manager-ui/`.
 
 ### Running frontend tests
 
+Tests are **Cypress Component Testing** (`*.cy.ts` files colocated with the code under test) plus a separate Cypress E2E suite — there is no Karma/Jasmine setup.
+
 ```bash
 cd JPPhotoManagerWeb/frontend
+
+# Component tests, headless (what CI runs)
 npm test
 
-# Headless (CI)
-npm test -- --watch=false --browsers=ChromeHeadless
+# Component tests with code coverage
+npm run test:coverage
+
+# End-to-end tests, headless (requires the app running — see e2e-testing skill)
+npm run test:e2e
+
+# Interactive Cypress runner (component mode)
+npm run cypress:open
+
+# Interactive Cypress runner (e2e mode)
+npm run cypress:e2e
+
+# Lint
+npm run lint
 ```
 
 ---
@@ -737,7 +945,8 @@ If you have an existing catalog in a **host PostgreSQL instance** and want to mo
 | `db` | `postgres:18` | `5433` | PostgreSQL 18; data persisted in the `pgdata` named volume |
 | `kafka` | `apache/kafka:3.9.0` | `9092` (internal) `9094` (host) | Apache Kafka in KRaft mode (no ZooKeeper); pub/sub backbone for catalog/sync/convert progress events. Port 9092 is for inter-container traffic; port 9094 exposes the broker to the host machine. |
 | `mongo` | `mongo:8` | `27017` | MongoDB 8; stores the `asset_audit_log` collection; data persisted in the `mongodata` named volume; no authentication configured |
-| `backend` | JRE 21 Alpine | `8080` | Spring Boot REST API; `HOST_IMAGE_DIR` bind-mounted at `/catalog`; connects to Kafka via `kafka:9092` |
+| `redis` | `redis:7-alpine` | `6379` | Redis 7 (`allkeys-lru` eviction, 256 MB cap); backs the thumbnail cache, `assets`/`tags`/`home-stats`/`sub-folders`/`asset-exif` query caches, refresh-token mirror, and rate limiting (Bucket4j); no persistent volume — cache-only, safe to lose |
+| `backend` | JRE 21 Alpine | `8080` | Spring Boot REST API; `HOST_IMAGE_DIR` bind-mounted at `/catalog`; connects to Kafka via `kafka:9092` and Redis via `redis:6379` |
 | `frontend` | Nginx Alpine | `80` | Angular SPA; reverse-proxies `/api` to the backend |
 | `prometheus` | `prom/prometheus` | `9090` | Scrapes backend metrics from `/actuator/prometheus` every 15 s |
 | `grafana` | `grafana/grafana` | `3000` | Dashboard UI backed by Prometheus |
@@ -753,6 +962,7 @@ After `docker compose up`, all services are reachable from the host machine:
 | Swagger UI | `http://localhost:8080/swagger-ui.html` | — |
 | PostgreSQL | `localhost:5433` | see table below |
 | MongoDB | `localhost:27017` | no auth — see below |
+| Redis | `localhost:6379` | no auth — cache only, safe to flush |
 | Kafka | `localhost:9094` | no auth — see below |
 | Prometheus | `http://localhost:9090` | — |
 | Grafana | `http://localhost:3000` | `admin` / value of `GRAFANA_ADMIN_PASSWORD` (default: `admin`) |
@@ -1141,6 +1351,9 @@ kubectl port-forward -n photomanager svc/db 5433:5432
 # MongoDB, for Compass/mongosh etc. (compose: localhost:27017)
 kubectl port-forward -n photomanager svc/mongo 27017:27017
 
+# Redis, for redis-cli etc. (compose: localhost:6379)
+kubectl port-forward -n photomanager svc/redis 6379:6379
+
 # Kafka, for KafkIO/kcat/kafka-*.bat etc. (compose: localhost:9094)
 # — needs one more step than the others; see the callout right below.
 kubectl port-forward -n photomanager svc/kafka 9094:9094
@@ -1383,13 +1596,17 @@ Logging is configured entirely via `src/main/resources/logback-spring.xml`. The 
 
 ## Authentication
 
-The application uses **JWT stored in an HttpOnly cookie** (`SameSite=Strict`, `Path=/`). All `/api/**` endpoints except `POST /api/auth/login` require this cookie. Because the browser attaches cookies automatically to every same-origin request — including `<img src="...">` image loads and the native `EventSource` API — no custom `Authorization` header is needed and there is no risk of token theft via JavaScript.
+The application uses **JWT stored in an HttpOnly cookie** (`SameSite=Strict`, `Path=/`), alongside a longer-lived `refreshToken` HttpOnly cookie used only to obtain a new JWT. All `/api/**` endpoints require the `jwt` cookie except the three under `/api/auth/` below. Because the browser attaches cookies automatically to every same-origin request — including `<img src="...">` image loads and the native `EventSource` API — no custom `Authorization` header is needed and there is no risk of token theft via JavaScript.
 
-### Public endpoint
+### Public endpoints
 
 | Method | Path | Description |
 |---|---|---|
-| `POST` | `/api/auth/login` | Authenticate; sets `jwt` HttpOnly cookie and returns `{ "username": "...", "expiresAt": "..." }` |
+| `POST` | `/api/auth/login` | Authenticate; sets `jwt` + `refreshToken` HttpOnly cookies and returns `{ "username": "...", "expiresAt": "..." }` |
+| `POST` | `/api/auth/refresh` | Reads the `refreshToken` cookie, rotates both cookies, and returns the same response shape as login |
+| `POST` | `/api/auth/logout` | Clears both cookies server-side |
+
+`GET /api/auth/me` also exists but is **not** public — it requires the `jwt` cookie and returns the current user's `{ "username": "...", "role": "..." }`.
 
 ### JWT flow
 
@@ -1408,8 +1625,10 @@ sequenceDiagram
     Angular->>API: POST /api/auth/login {username, password}
     API->>DB: Look up user, verify BCrypt hash
     DB-->>API: User record
-    API-->>Angular: Set-Cookie: jwt=<token> (HttpOnly, SameSite=Strict) + {username, expiresAt}
-    Angular->>Angular: Store {username, expiresAt} in localStorage
+    API-->>Angular: Set-Cookie: jwt=<token>; refreshToken=<token> (HttpOnly, SameSite=Strict) + {username, expiresAt}
+    Angular->>API: GET /api/auth/me (cookie sent by browser)
+    API-->>Angular: {username, role}
+    Angular->>Angular: Store {username, expiresAt, role} in localStorage
     Angular->>Angular: Schedule proactive refresh at (expiresAt − 5 min)
     Angular-->>User: Redirect to /home
 
@@ -1420,7 +1639,7 @@ sequenceDiagram
     API-->>Angular: 200 OK + data
 
     Angular->>API: POST /api/auth/logout
-    API-->>Angular: Set-Cookie: jwt=; Max-Age=0 (clears cookie)
+    API-->>Angular: Set-Cookie: jwt=; refreshToken=; Max-Age=0 (clears both cookies)
     Angular->>Angular: Clear localStorage + cancel refresh timer
     Angular-->>User: Redirect to /login
 ```
@@ -1430,7 +1649,8 @@ sequenceDiagram
 | Property | Default | Description |
 |---|---|---|
 | `photomanager.jwt-secret` | *(empty — must be set)* | HS256 signing secret (≥ 32 bytes) |
-| `photomanager.jwt-expiry-hours` | `24` | Token validity in hours |
+| `photomanager.jwt-expiry-hours` | `24` | JWT access-token validity in hours |
+| `photomanager.refresh-token-expiry-days` | `30` | Refresh-token validity in days |
 
 ### Generating JWT_SECRET
 

--- a/Readme.md
+++ b/Readme.md
@@ -43,26 +43,41 @@ Open the solution file `JPPhotoManager/JPPhotoManager.sln` and run the `JPPhotoM
 
 ## Web Application
 
-JPPhotoManager Web is a browser-based rewrite of the desktop application, built with a **Java 21 + Spring Boot 3** REST API backend and an **Angular 19** single-page application frontend.
+JPPhotoManager Web is a browser-based rewrite of the desktop application, built with a **Java 21 + Spring Boot 3.4** REST API backend and an **Angular 19** single-page application frontend. See [`JPPhotoManagerWeb/README.md`](JPPhotoManagerWeb/README.md) for full documentation, architecture diagrams, and deployment instructions.
 
 ### Features
-* Visualization of image galleries (thumbnail grid and full-size viewer)
-* Find duplicates
-* Copy/move images between folders
+* Visualization of image galleries — paginated thumbnail grid, full-size viewer, search/filter/sort, and star ratings
+* Albums — create, rename, delete, and organize images into personal albums
+* Find duplicates (SHA-256 hash based)
+* Copy/move images between catalogued folders, drag-and-drop upload, ZIP download
+* Recycle Bin — soft-deleted images can be restored or permanently purged
 * Sync images between directory pairs
 * Convert PNG images to JPEG
-* Streaming real-time progress for long-running operations via Server-Sent Events
+* JWT authentication (HttpOnly cookie) and user administration
+* Dashboard with at-a-glance catalog statistics
+* Streaming real-time progress for long-running operations via Kafka-mediated Server-Sent Events
+* Prometheus + Grafana monitoring dashboards
 
 ### Run the web application
 
-**Backend** (requires Java 21 and Maven 3.9+):
+**Fastest — Docker Compose** (no local Java, Maven, Node.js, or database installation required):
+```bash
+cd JPPhotoManagerWeb
+cp .env.example .env   # set HOST_IMAGE_DIR and JWT_SECRET
+docker compose up --build
+```
+Open `http://localhost` in your browser.
+
+**Manual setup:**
+
+Backend (requires Java 21, Maven 3.9+, PostgreSQL 18, and Apache Kafka):
 ```bash
 cd JPPhotoManagerWeb/backend
 mvn spring-boot:run
 ```
-The API starts at `http://localhost:8080`.
+The API starts at `http://localhost:8080` (Swagger UI at `/swagger-ui.html`).
 
-**Frontend** (requires Node.js 22):
+Frontend (requires Node.js 22):
 ```bash
 cd JPPhotoManagerWeb/frontend
 npm install
@@ -70,11 +85,19 @@ npm start
 ```
 Open `http://localhost:4200` in your browser. The dev server automatically proxies `/api` requests to the backend.
 
+A Kubernetes deployment (manifests under `JPPhotoManagerWeb/k8s/`) is also available — see the web application README for details.
+
 ### Technologies used (web application)
 * [Java 21](https://openjdk.org/)
-* [Spring Boot 3](https://spring.io/projects/spring-boot)
+* [Spring Boot 3.4](https://spring.io/projects/spring-boot)
 * [Spring Data JPA](https://spring.io/projects/spring-data-jpa)
-* [SQLite](https://www.sqlite.org/index.html)
+* [Spring Security](https://spring.io/projects/spring-security) + [JJWT](https://github.com/jwtk/jjwt)
+* [Spring Batch](https://spring.io/projects/spring-batch)
+* [Spring Kafka](https://spring.io/projects/spring-kafka)
+* [PostgreSQL](https://www.postgresql.org/)
+* [MongoDB](https://www.mongodb.com/)
+* [Redis](https://redis.io/)
+* [Apache Kafka](https://kafka.apache.org/)
 * [Flyway](https://flywaydb.org/)
 * [Lombok](https://projectlombok.org/)
 * [MapStruct](https://mapstruct.org/)
@@ -85,3 +108,6 @@ Open `http://localhost:4200` in your browser. The dev server automatically proxi
 * [JUnit 5](https://junit.org/junit5/)
 * [Mockito](https://site.mockito.org/)
 * [AssertJ](https://assertj.github.io/doc/)
+* [Docker](https://www.docker.com/) / [Docker Compose](https://docs.docker.com/compose/)
+* [Kubernetes](https://kubernetes.io/)
+* [Prometheus](https://prometheus.io/) + [Grafana](https://grafana.com/)


### PR DESCRIPTION
The section still described the early web rewrite (SQLite, no auth,
no messaging/caching layer). Bring it in line with the current
PostgreSQL + MongoDB + Redis + Kafka architecture, JWT auth, albums,
recycle bin, and Docker/Kubernetes deployment options documented in
JPPhotoManagerWeb/README.md.