### PR TITLE
Fix rename overwrite bug and stale immutable thumbnail caching

### DIFF
--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/application/usecase/asset/RenameAssetsUseCaseImpl.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/application/usecase/asset/RenameAssetsUseCaseImpl.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -144,18 +145,27 @@ public class RenameAssetsUseCaseImpl implements RenameAssetsUseCase {
     private void checkFolderCollisions(List<RenamePreview> previews, List<Asset> assets) {
         Set<Long> batchIds = assets.stream().map(Asset::getAssetId).collect(Collectors.toSet());
 
-        // Group target names by folder path to make one DB call per folder
+        // Group target names and vacated (old) names by folder path
         Map<String, Set<String>> targetNamesByFolderPath = new HashMap<>();
+        Map<String, Set<String>> vacatedNamesByFolderPath = new HashMap<>();
         for (int i = 0; i < assets.size(); i++) {
             String folderPath = assets.get(i).getFolder().getPath();
             targetNamesByFolderPath
                     .computeIfAbsent(folderPath, k -> new HashSet<>())
                     .add(previews.get(i).newName());
+            vacatedNamesByFolderPath
+                    .computeIfAbsent(folderPath, k -> new HashSet<>())
+                    .add(assets.get(i).getFileName());
         }
 
-        for (int i = 0; i < assets.size(); i++) {
-            Asset asset = assets.get(i);
-            Set<String> folderTargets = targetNamesByFolderPath.get(asset.getFolder().getPath());
+        Set<String> checkedFolderPaths = new HashSet<>();
+        for (Asset asset : assets) {
+            String folderPath = asset.getFolder().getPath();
+            if (!checkedFolderPaths.add(folderPath)) {
+                continue; // this folder was already checked for a previous asset in the batch
+            }
+            Set<String> folderTargets = targetNamesByFolderPath.get(folderPath);
+
             List<Asset> folderAssets = assetRepository.findByFolder(asset.getFolder());
             for (Asset existing : folderAssets) {
                 if (!batchIds.contains(existing.getAssetId())
@@ -163,8 +173,17 @@ public class RenameAssetsUseCaseImpl implements RenameAssetsUseCase {
                     throw new IllegalArgumentException("ASSET_NAME_COLLISION");
                 }
             }
-            // Only query each folder once
-            targetNamesByFolderPath.remove(asset.getFolder().getPath());
+
+            // Also guard against files that exist on disk but aren't catalogued yet —
+            // storagePort.moveFile() overwrites its destination unconditionally, so without
+            // this check an un-catalogued file sharing a target name is silently destroyed.
+            Set<String> vacatedNames = vacatedNamesByFolderPath.get(folderPath);
+            for (String existingFilePath : storagePort.listFiles(folderPath)) {
+                String existingFileName = Paths.get(existingFilePath).getFileName().toString();
+                if (!vacatedNames.contains(existingFileName) && folderTargets.contains(existingFileName)) {
+                    throw new IllegalArgumentException("ASSET_NAME_COLLISION");
+                }
+            }
         }
     }
 

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/application/usecase/home/GetHomeStatsUseCaseImpl.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/application/usecase/home/GetHomeStatsUseCaseImpl.java
@@ -38,7 +38,7 @@ public class GetHomeStatsUseCaseImpl implements GetHomeStatsUseCase {
                         a.getAssetId(),
                         a.getFileName(),
                         a.getFolder().getPath(),
-                        "/api/assets/" + a.getAssetId() + "/thumbnail",
+                        a.getThumbnailUrl(),
                         a.getFileSize()))
                 .toList();
         Instant lastCatalogCompletedAt = catalogRunHistoryPort.findLastCompletedCatalogRunTime().orElse(null);

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/Asset.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/domain/model/Asset.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -47,6 +48,18 @@ public class Asset {
 
     public String getThumbnailBlobName() {
         return assetId + ".bin";
+    }
+
+    // The thumbnail endpoint is served with a far-future, immutable Cache-Control header (see
+    // AssetController.getThumbnail) — safe only because this "?v=" token changes whenever the
+    // underlying thumbnail bytes do (recatalogued from scratch after a data wipe reuses low
+    // asset IDs for entirely different files; a reprocess regenerates the thumbnail under the
+    // same ID). Without it, browsers that already cached the old URL never re-fetch.
+    public String getThumbnailUrl() {
+        String base = "/api/assets/" + assetId + "/thumbnail";
+        return thumbnailCreationDateTime != null
+                ? base + "?v=" + thumbnailCreationDateTime.toEpochSecond(ZoneOffset.UTC)
+                : base;
     }
 
     public String getFullPath() {

--- a/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/web/mapper/AssetWebMapper.java
+++ b/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/web/mapper/AssetWebMapper.java
@@ -24,8 +24,7 @@ public interface AssetWebMapper {
 
     @Mapping(source = "folder.folderId", target = "folderId")
     @Mapping(source = "folder.path", target = "folderPath")
-    @Mapping(target = "thumbnailUrl",
-             expression = "java(\"/api/assets/\" + asset.getAssetId() + \"/thumbnail\")")
+    @Mapping(target = "thumbnailUrl", expression = "java(asset.getThumbnailUrl())")
     @Mapping(target = "imageUrl",
              expression = "java(\"/api/assets/\" + asset.getAssetId() + \"/image\")")
     @Mapping(source = "tags", target = "tags", qualifiedByName = "tagsSetToList")

--- a/JPPhotoManagerWeb/backend/src/test/java/com/jpablodrexler/photomanager/HomeStatsIntegrationTest.java
+++ b/JPPhotoManagerWeb/backend/src/test/java/com/jpablodrexler/photomanager/HomeStatsIntegrationTest.java
@@ -138,13 +138,15 @@ class HomeStatsIntegrationTest {
         folder = folderRepository.save(folder);
 
         Asset saved = saveAsset(folder, "recent.jpg", 500L, "hash-recent-" + System.nanoTime(), LocalDateTime.now());
+        long expectedVersion = saved.getThumbnailCreationDateTime().toEpochSecond(java.time.ZoneOffset.UTC);
 
         mockMvc.perform(get("/api/home/stats"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.recentAssets").isArray())
                 .andExpect(jsonPath("$.recentAssets[0].fileName").value("recent.jpg"))
                 .andExpect(jsonPath("$.recentAssets[0].folderPath").value(folder.getPath()))
-                .andExpect(jsonPath("$.recentAssets[0].thumbnailUrl").value("/api/assets/" + saved.getAssetId() + "/thumbnail"));
+                .andExpect(jsonPath("$.recentAssets[0].thumbnailUrl")
+                        .value("/api/assets/" + saved.getAssetId() + "/thumbnail?v=" + expectedVersion));
     }
 
     private Asset saveAsset(Folder folder, String fileName, long fileSize, String hash, LocalDateTime thumbnailCreationDateTime) {

--- a/JPPhotoManagerWeb/backend/src/test/java/com/jpablodrexler/photomanager/application/usecase/asset/RenameAssetsUseCaseImplTest.java
+++ b/JPPhotoManagerWeb/backend/src/test/java/com/jpablodrexler/photomanager/application/usecase/asset/RenameAssetsUseCaseImplTest.java
@@ -133,6 +133,56 @@ class RenameAssetsUseCaseImplTest {
         verify(storagePort, never()).moveFile(any(), any());
     }
 
+    @Test
+    void execute_uncatalogedFileAlreadyOnDiskAtTargetName_throwsIllegalArgumentExceptionAndDoesNotOverwriteIt() throws Exception {
+        Asset batchAsset = buildAsset(1L, "old.png", null);
+        when(assetRepository.findAllById(List.of(1L))).thenReturn(List.of(batchAsset));
+        when(assetRepository.findByFolder(batchAsset.getFolder())).thenReturn(List.of(batchAsset));
+        // logo.png exists on disk but was never catalogued, so the DB-only check alone would miss it
+        when(storagePort.listFiles(FOLDER_PATH)).thenReturn(List.of(FOLDER_PATH + "/logo.png"));
+
+        assertThatThrownBy(() -> sut.execute(new Long[]{1L}, "logo.{ext}", true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ASSET_NAME_COLLISION");
+
+        verify(storagePort, never()).moveFile(any(), any());
+    }
+
+    @Test
+    void execute_renameOntoOwnCurrentFileName_doesNotFlagFalseCollisionFromDisk() throws Exception {
+        // A no-op rename (pattern happens to reproduce the current file name) must not be
+        // treated as a collision against the asset's own file already present on disk.
+        Asset asset = buildAsset(1L, "old.jpg", null);
+        when(assetRepository.findAllById(List.of(1L))).thenReturn(List.of(asset));
+        when(assetRepository.findByFolder(asset.getFolder())).thenReturn(List.of(asset));
+        when(storagePort.listFiles(FOLDER_PATH)).thenReturn(List.of(FOLDER_PATH + "/old.jpg"));
+        when(assetRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        RenameAssetsResult result = sut.execute(new Long[]{1L}, "old.{ext}", true);
+
+        assertThat(result.applied()).isTrue();
+        verify(storagePort).moveFile(FOLDER_PATH + "/old.jpg", FOLDER_PATH + "/old.jpg");
+    }
+
+    @Test
+    void execute_multipleAssetsInSameFolder_checksCollisionsForEachAssetWithoutError() throws Exception {
+        // Regression test: checkFolderCollisions used to remove a folder's entry from its
+        // lookup map after checking the first asset, so a second batch member in the same
+        // folder would hit a NullPointerException instead of being checked at all.
+        Asset a1 = buildAsset(1L, "a.jpg", null);
+        Asset a2 = buildAsset(2L, "b.jpg", null);
+        Asset unrelated = buildAsset(99L, "keepme.jpg", null);
+        when(assetRepository.findAllById(List.of(1L, 2L))).thenReturn(List.of(a1, a2));
+        when(assetRepository.findByFolder(a1.getFolder())).thenReturn(List.of(a1, a2, unrelated));
+        when(assetRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        RenameAssetsResult result = sut.execute(new Long[]{1L, 2L}, "new_{index:01d}.{ext}", true);
+
+        assertThat(result.applied()).isTrue();
+        verify(storagePort).moveFile(FOLDER_PATH + "/a.jpg", FOLDER_PATH + "/new_1.jpg");
+        verify(storagePort).moveFile(FOLDER_PATH + "/b.jpg", FOLDER_PATH + "/new_2.jpg");
+    }
+
     // --- preview-only mode ---
 
     @Test

--- a/JPPhotoManagerWeb/backend/src/test/java/com/jpablodrexler/photomanager/infrastructure/batch/CatalogBatchConcurrencyIntegrationTest.java
+++ b/JPPhotoManagerWeb/backend/src/test/java/com/jpablodrexler/photomanager/infrastructure/batch/CatalogBatchConcurrencyIntegrationTest.java
@@ -1,0 +1,144 @@
+package com.jpablodrexler.photomanager.infrastructure.batch;
+
+import com.jpablodrexler.photomanager.PostgresIntegrationTest;
+import com.jpablodrexler.photomanager.domain.model.Asset;
+import com.jpablodrexler.photomanager.domain.port.in.catalog.CatalogAssetsUseCase;
+import com.jpablodrexler.photomanager.domain.port.out.AssetRepository;
+import com.jpablodrexler.photomanager.domain.port.out.ThumbnailPort;
+import com.jpablodrexler.photomanager.infrastructure.service.CatalogScheduler;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import javax.imageio.ImageIO;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduces a real, multi-folder catalog scan under genuine partition concurrency (unlike
+ * {@link CatalogBatchIntegrationTest}, which only ever exercises a single folder / single
+ * partition) to check whether a file in one folder can ever end up persisted with another
+ * file's thumbnail bytes. Each folder gets a distinct, recognizable solid-color image so a
+ * cross-partition mix-up is directly observable by decoding the persisted thumbnail.
+ */
+@SpringBatchTest
+@EmbeddedKafka(partitions = 1, topics = {
+    "job.catalog.progress", "job.sync.progress", "job.convert.progress",
+    "asset.cataloged", "asset.deleted"
+})
+@WithMockUser(roles = "ADMIN")
+class CatalogBatchConcurrencyIntegrationTest extends PostgresIntegrationTest {
+
+    static final Path tempDir;
+
+    // fileName (without extension) -> solid fill color; one distinct subfolder per entry so
+    // CatalogFolderPartitioner creates one partition per color, and the grid size below is
+    // set to match so every partition actually runs concurrently rather than queueing through
+    // a smaller thread pool.
+    private static final Map<String, Color> COLOR_FOLDERS = new LinkedHashMap<>();
+
+    static {
+        try {
+            tempDir = Files.createTempDirectory("catalog-batch-concurrency-test");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        COLOR_FOLDERS.put("red", new Color(220, 20, 20));
+        COLOR_FOLDERS.put("green", new Color(20, 220, 20));
+        COLOR_FOLDERS.put("blue", new Color(20, 20, 220));
+        COLOR_FOLDERS.put("yellow", new Color(220, 220, 20));
+        COLOR_FOLDERS.put("magenta", new Color(220, 20, 220));
+        COLOR_FOLDERS.put("cyan", new Color(20, 220, 220));
+        COLOR_FOLDERS.put("orange", new Color(230, 140, 20));
+        COLOR_FOLDERS.put("purple", new Color(120, 20, 200));
+    }
+
+    @DynamicPropertySource
+    static void overrideCatalogFolder(DynamicPropertyRegistry registry) {
+        registry.add("photomanager.root-catalog-folders", () -> tempDir.toAbsolutePath().toString());
+        registry.add("photomanager.catalog-partition-grid-size", () -> String.valueOf(COLOR_FOLDERS.size()));
+    }
+
+    @MockitoBean
+    CatalogScheduler catalogScheduler;
+
+    @Autowired
+    AssetRepository assetRepository;
+
+    @Autowired
+    ThumbnailPort thumbnailPort;
+
+    @Autowired
+    CatalogAssetsUseCase catalogAssetsUseCase;
+
+    @BeforeAll
+    static void createColorFolders() throws IOException {
+        for (Map.Entry<String, Color> entry : COLOR_FOLDERS.entrySet()) {
+            Path folder = Files.createDirectories(tempDir.resolve(entry.getKey()));
+            writeSolidColorPng(folder.resolve(entry.getKey() + ".png"), entry.getValue());
+        }
+    }
+
+    private static void writeSolidColorPng(Path target, Color color) throws IOException {
+        BufferedImage image = new BufferedImage(64, 64, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = image.createGraphics();
+        g.setColor(color);
+        g.fillRect(0, 0, 64, 64);
+        g.dispose();
+        ImageIO.write(image, "png", target.toFile());
+    }
+
+    @Test
+    void catalogJob_manyFoldersConcurrently_everyAssetGetsItsOwnThumbnail() throws Exception {
+        catalogAssetsUseCase.execute(System.currentTimeMillis(), null).get(60, TimeUnit.SECONDS);
+
+        List<Asset> assets = assetRepository.findAll();
+        assertThat(assets).hasSize(COLOR_FOLDERS.size());
+
+        for (Asset asset : assets) {
+            String colorName = asset.getFileName().substring(0, asset.getFileName().lastIndexOf('.'));
+            Color expected = COLOR_FOLDERS.get(colorName);
+            assertThat(expected)
+                    .as("asset %s (id=%d) has an unexpected file name", asset.getFileName(), asset.getAssetId())
+                    .isNotNull();
+
+            byte[] thumbnailBytes = thumbnailPort.loadThumbnail(asset.getThumbnailBlobName());
+            assertThat(thumbnailBytes)
+                    .as("asset %s (id=%d) has no thumbnail stored", asset.getFileName(), asset.getAssetId())
+                    .isNotNull();
+
+            BufferedImage decoded = ImageIO.read(new ByteArrayInputStream(thumbnailBytes));
+            Color actual = new Color(decoded.getRGB(decoded.getWidth() / 2, decoded.getHeight() / 2));
+
+            assertThat(colorDistance(actual, expected))
+                    .as("asset %s (id=%d, blob=%s) should be %s but its stored thumbnail decodes to %s"
+                            + " — this means a different folder's file wrote this asset's thumbnail",
+                            asset.getFileName(), asset.getAssetId(), asset.getThumbnailBlobName(), expected, actual)
+                    .isLessThan(60);
+        }
+    }
+
+    private static double colorDistance(Color a, Color b) {
+        int dr = a.getRed() - b.getRed();
+        int dg = a.getGreen() - b.getGreen();
+        int db = a.getBlue() - b.getBlue();
+        return Math.sqrt(dr * dr + dg * dg + db * db);
+    }
+}

--- a/JPPhotoManagerWeb/backend/src/test/java/com/jpablodrexler/photomanager/infrastructure/web/mapper/WebMappersTest.java
+++ b/JPPhotoManagerWeb/backend/src/test/java/com/jpablodrexler/photomanager/infrastructure/web/mapper/WebMappersTest.java
@@ -55,7 +55,8 @@ class WebMappersTest {
         assertThat(dto.getImageRotation()).isEqualTo(ImageRotation.ROTATE_0);
         assertThat(dto.getHash()).isEqualTo("abc123");
         assertThat(dto.getRating()).isEqualTo(4);
-        assertThat(dto.getThumbnailUrl()).isEqualTo("/api/assets/42/thumbnail");
+        long expectedVersion = LocalDateTime.of(2024, 1, 1, 0, 0).toEpochSecond(java.time.ZoneOffset.UTC);
+        assertThat(dto.getThumbnailUrl()).isEqualTo("/api/assets/42/thumbnail?v=" + expectedVersion);
         assertThat(dto.getImageUrl()).isEqualTo("/api/assets/42/image");
     }
 
@@ -67,6 +68,15 @@ class WebMappersTest {
 
         assertThat(dto.getFolderId()).isNull();
         assertThat(dto.getFolderPath()).isNull();
+    }
+
+    @Test
+    void assetWebMapper_toDto_noThumbnailCreationDateTime_omitsVersionQueryParam() {
+        Asset asset = Asset.builder().assetId(1L).fileName("a.jpg").build();
+
+        AssetResponseDto dto = assetWebMapper.toDto(asset);
+
+        assertThat(dto.getThumbnailUrl()).isEqualTo("/api/assets/1/thumbnail");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- **Rename silent overwrite**: `RenameAssetsUseCaseImpl.checkFolderCollisions()` only checked target names against catalogued (DB-tracked) assets, never the real filesystem. Since `storagePort.moveFile()` uses `Files.move(..., REPLACE_EXISTING)`, a rename whose target name matched an un-catalogued file already on disk silently destroyed it. Now also checks the filesystem, excluding names the batch itself is about to vacate. Also fixes a latent bug in the same method where a second batch asset sharing a folder with an earlier one skipped its DB collision check entirely.
- **Stale immutable thumbnail caching**: thumbnails are served with `Cache-Control: immutable, max-age=1y`, but the URL was built from nothing but the asset's numeric ID. That's only safe if `assetId -> thumbnail content` never changes — which breaks the moment the catalog is wiped and rebuilt (e.g. via `cleanup-k8s.sh`): the `BIGSERIAL` sequence restarts, low IDs get reused for entirely different files, and browsers that already cached the old URL keep serving stale bytes forever. `Asset.getThumbnailUrl()` now appends a `?v=` token derived from `thumbnailCreationDateTime`, so the URL changes whenever the underlying thumbnail actually does. Wired into both places that built the raw URL (gallery + home "recent assets" widget).
- Adds `CatalogBatchConcurrencyIntegrationTest`, a stress test that catalogs distinctly-colored images across many concurrently-processed folders and verifies no cross-partition thumbnail mix-up — a part of the batch pipeline that had no concurrency coverage before.

## Test plan
- [x] Full backend unit suite passes (666 tests)
- [x] New/updated unit tests for both fixes pass
- [x] `CatalogBatchConcurrencyIntegrationTest` requires Docker/Testcontainers — not yet run in this environment (local Docker Desktop is resource-constrained running the full k8s stack); recommend running in CI or a machine with more headroom
- [x] Live verification against the real cluster where the thumbnail-mismatch bug was found is still pending — the redeploy triggered during investigation hasn't stabilized due to CPU contention on the local dev cluster (unrelated to the code change itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)