### PR TITLE
Restructure README so desktop and web applications are peer sections

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,11 @@
 [![Test](https://github.com/jpablodrexler/jp-photo-manager/actions/workflows/test.yml/badge.svg)](https://github.com/jpablodrexler/jp-photo-manager/actions/workflows/test.yml)
 [![Release](https://github.com/jpablodrexler/jp-photo-manager/actions/workflows/release.yaml/badge.svg)](https://github.com/jpablodrexler/jp-photo-manager/actions/workflows/release.yaml)
 
-## Features
+## Desktop Application
+
+JPPhotoManager Desktop is a Windows Presentation Foundation (WPF) application for managing local photo collections.
+
+### Features
 JPPhotoManager is a desktop application that allows:
 * Visualization of image galleries
 * Change Windows wallpaper
@@ -17,16 +21,16 @@ JPPhotoManager is a desktop application that allows:
 * Export images to shared folders in the local network
 * Delete images in local or shared folders that are not present in source folder
 
-## Run the application
+### Run the application
 Open the solution file `JPPhotoManager/JPPhotoManager.sln` and run the `JPPhotoManager/JPPhotoManager.UI/JPPhotoManager.UI.csproj` project.
 
-## Installation instructions
+### Installation instructions
 * Download the zip file with the compiled application files (`publish.zip` or `jp-photo-manager-{version}.zip`) for the latest release.
 * Unzip the content of the zip file to a new folder.
 * Run `JPPhotoManager.UI.exe`.
 * The application saves the catalog files in the following folder: `C:\Users\{username}\AppData\Local\JPPhotoManager`.
 
-## Technologies used
+### Technologies used (desktop application)
 * [.NET 8.0](https://dotnet.microsoft.com/)
 * [Windows Presentation Foundation](https://docs.microsoft.com/en-us/dotnet/framework/wpf/)
 * [Entity Framework Core](https://github.com/dotnet/efcore)


### PR DESCRIPTION
## Summary
- Desktop app content previously sat directly under the title (implicit, unlabeled), while the web app was nested as its own section — asymmetric structure.
- Both are now `## Desktop Application` / `## Web Application` sibling sections with matching `###` subsections (Features, Run, Installation/Setup, Technologies used).

## Test plan
- [x] Rendered README structure reviewed for consistent heading levels
- N/A — documentation-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)