### PR TITLE
Feature skills-gitflow

### DIFF
--- a/.claude/skills/feature-development/SKILL.md
+++ b/.claude/skills/feature-development/SKILL.md
@@ -31,7 +31,7 @@ Five phases executed by six dedicated subagents (3a and 3b run in parallel):
 
 | Phase                  | Subagent   | Skills / actions                                                                                                                                  |
 | ---------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1 — Select & Propose   | Subagent 1 | `features-next` (confirm only) → create `feature/<change-name>` branch from `develop` → `openspec-propose` (if artifacts missing)                 |
+| 1 — Select & Propose   | Subagent 1 | `features-next` (confirm only) → `gitflow` (start feature) to create `feature/<change-name>` branch from `develop` → `openspec-propose` (if artifacts missing) |
 | 2 — Implement & Review | Subagent 2 | `openspec-apply-change <name>` + `code-reviewer` + `database-reviewer` + `security-reviewer` (conditional, findings fixed before done)          |
 | 3a — Backend tests     | Subagent 3 | runs `cd JPPhotoManagerWeb/backend && mvn test` until passing                                                                                     |
 | 3b — Frontend tests    | Subagent 4 | runs `cd JPPhotoManagerWeb/frontend && npm test` until passing                                                                                    |
@@ -72,10 +72,14 @@ prompt (substitute `<input>` with the argument passed to this skill, if any):
 > 2. Run: `git rev-parse --verify --quiet feature/<change-name>`
 >    - If it prints a commit hash, the branch already exists (resuming a
 >      prior run): run `git checkout feature/<change-name>` and continue on
->      that branch.
->    - If it fails (branch doesn't exist yet): run `git checkout develop`
->      then `git checkout -b feature/<change-name> develop` to cut the new
->      branch from `develop`.
+>      that branch — do not invoke `gitflow` for this case, it only creates
+>      new branches.
+>    - If it fails (branch doesn't exist yet): use the Skill tool to invoke
+>      `gitflow` with the action "start feature `<change-name>`". It checks
+>      out `develop`, pulls the latest, and creates `feature/<change-name>`
+>      from it. If it reports a blocker (e.g. `develop` doesn't fast-forward
+>      cleanly), end your response with `PROPOSE_BLOCKED — <the gitflow
+>      blocker>` and stop.
 > 3. Run `git branch --show-current` and confirm the output is exactly
 >    `feature/<change-name>` before proceeding. If it is not, end your
 >    response with `PROPOSE_BLOCKED — could not switch to feature branch`
@@ -600,11 +604,13 @@ After all phases complete, display:
   (see Step 4 above).
 - **Work always happens on a `feature/<change-name>` branch cut from
   `develop`.** Phase 1's Step 1.5 is the only place a branch is created or
-  switched — it creates (or resumes) `feature/<change-name>` from `develop`
-  before any file in the repository is created or modified, including the
-  SDD artifacts written by `openspec-propose`. Phases 2–5 must stay on that
-  branch; none of them may run `git checkout`, `git switch`, or create
-  another branch. If a subagent finds itself on a different branch, that is
+  switched — it invokes the `gitflow` skill (start feature) to create
+  `feature/<change-name>` from `develop`, or resumes it directly if it
+  already exists from a prior run, before any file in the repository is
+  created or modified, including the SDD artifacts written by
+  `openspec-propose`. Phases 2–5 must stay on that branch; none of them may
+  run `git checkout`, `git switch`, invoke `gitflow`, or create another
+  branch. If a subagent finds itself on a different branch, that is
   a bug in the workflow — surface it to the user rather than silently
   switching.
 - **No git commits at any point.** Neither this skill nor any subagent it

--- a/.claude/skills/gitflow/SKILL.md
+++ b/.claude/skills/gitflow/SKILL.md
@@ -38,7 +38,7 @@ Map the user's request to one of:
 - **finish hotfix** (operates on the current hotfix branch, or one named explicitly)
 - **tag release** `<version>` / **tag hotfix** `<version>`
 
-If the name/version wasn't given and can't be inferred from the current branch, ask for it.
+If the name/version wasn't given and can't be inferred from the current branch, ask for it. For **finish feature** specifically, if no name is given explicitly, infer it from the current branch name by stripping the `feature/` prefix (e.g. current branch `feature/skills-gitflow` → name `skills-gitflow`) — no need to ask the user in this case.
 
 ### 2. Check working tree state
 

--- a/.claude/skills/gitflow/SKILL.md
+++ b/.claude/skills/gitflow/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: gitflow
+description: Encapsulates the Gitflow branching workflow for this repo (develop as integration branch, main as production branch). TRIGGER when the user asks to start/create a new feature, release, or hotfix branch, when asking to merge/finish a release or hotfix, or when asking to tag a release or hotfix after it has been merged. Phrases like "start a new feature", "create a release branch", "start a hotfix", "merge the release", "finish the hotfix", "tag the release" all trigger this skill.
+license: MIT
+metadata:
+  author: Juan Pablo Drexler
+  version: "1.0"
+---
+
+Perform one Gitflow action: start a feature/release/hotfix branch, finish (open PRs for) a release/hotfix, or tag main after a release/hotfix PR has merged.
+
+**Input**: The action (`start feature`, `start release`, `start hotfix`, `finish release`, `finish hotfix`, `tag release`, `tag hotfix`) plus a name/version. If the action is ambiguous from the user's request, infer it from phrasing (see TRIGGER examples above) and confirm the target name/version with the user before acting if it wasn't given explicitly.
+
+---
+
+## Branch and tag conventions (fixed for this repo)
+
+| Branch type | Created from | Prefix       | Finishes into      |
+|-------------|--------------|--------------|---------------------|
+| feature     | `develop`    | `feature/`   | `develop` (not automated by this skill) |
+| release     | `develop`    | `release/`   | `main` **and** `develop` via PR |
+| hotfix      | `main`       | `hotfix/`    | `main` **and** `develop` via PR |
+
+Version tags on `main` use the `v<major>.<minor>.<patch>` format (e.g. `v2.1.0`), matching this repo's existing tag history.
+
+---
+
+## Steps
+
+### 1. Determine the action
+
+Map the user's request to one of:
+- **start feature** `<name>`
+- **start release** `<version>`
+- **start hotfix** `<version>`
+- **finish release** (operates on the current release branch, or one named explicitly)
+- **finish hotfix** (operates on the current hotfix branch, or one named explicitly)
+- **tag release** `<version>` / **tag hotfix** `<version>`
+
+If the name/version wasn't given and can't be inferred from the current branch, ask for it.
+
+### 2. Check working tree state
+
+Run `git status`. If there are uncommitted changes, stop and tell the user — do not stash or discard automatically.
+
+### 3a. Start feature / release / hotfix
+
+1. Determine the base branch: `develop` for feature/release, `main` for hotfix.
+2. `git checkout <base>`
+3. `git pull origin <base>` — fail loudly if this doesn't fast-forward cleanly (don't force).
+4. `git checkout -b <prefix>/<name-or-version>` where prefix is `feature`, `release`, or `hotfix`.
+5. Report the new branch name and its base. Do not push automatically — let the user decide when to push.
+
+### 3b. Finish release / Finish hotfix (open PRs)
+
+Preconditions:
+- Current branch (or the one named explicitly) must start with `release/` or `hotfix/` matching the action.
+- Branch must exist on the remote — if not, push it first: `git push -u origin <branch>` (confirm with the user before pushing if this is the first push of the branch).
+
+Steps:
+1. `gh pr create --base main --head <branch> --title "<Release|Hotfix> <version>" --body "..."` — PR into `main`.
+2. `gh pr create --base develop --head <branch> --title "<Release|Hotfix> <version>" --body "..."` — PR into `develop`.
+3. Report both PR URLs to the user.
+
+This step **only opens the PRs** — it does not merge them. Merging goes through normal GitHub review. Do not auto-merge.
+
+Note in the summary: once the PR into `main` is merged, run the **tag release/hotfix** action to tag `main` with the version.
+
+### 3c. Tag release / Tag hotfix
+
+This step must run **after** the PR into `main` has actually been merged — it tags the resulting commit on `main`, matching Gitflow's convention of tagging production merges.
+
+1. Verify the merge happened: `gh pr list --state merged --base main --head <release/hotfix-branch> --json number,mergedAt`. If no merged PR is found, stop and tell the user to merge the PR into `main` first — do not tag speculatively.
+2. `git checkout main`
+3. `git pull origin main`
+4. Confirm the tag name with the user: `v<version>` (strip any `release/`/`hotfix/` prefix and leading `v` from the input, then re-add a single `v`).
+5. Check the tag doesn't already exist: `git tag --list v<version>`.
+6. Ask the user to confirm before pushing the tag (this is a shared, hard-to-reverse action visible to everyone with repo access).
+7. `git tag -a v<version> -m "<Release|Hotfix> <version>"`
+8. `git push origin v<version>`
+9. Report the pushed tag.
+
+---
+
+## Guardrails
+
+- Never force-push, force-create branches over existing ones, or delete branches as part of this skill.
+- Never merge a PR automatically — "finish release/hotfix" only creates the PRs; merging is a human review step.
+- Never tag `main` without first confirming (via `gh pr list --state merged`) that the corresponding release/hotfix PR into `main` has actually merged.
+- Never tag without explicit user confirmation immediately before the `git push origin <tag>` — pushing a tag is visible to the whole team and awkward to undo.
+- If the working tree has uncommitted changes at the start of any action, stop and report — never stash or discard automatically.
+- If `git pull` on the base branch doesn't fast-forward cleanly, stop and report — never force-merge or rebase automatically.
+- `feature/*` branches only ever merge back into `develop`, never into `main` directly, and this skill does not automate that merge — feature integration typically happens via normal PR review into `develop`, outside this skill's "finish" actions.

--- a/.claude/skills/gitflow/SKILL.md
+++ b/.claude/skills/gitflow/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: gitflow
-description: Encapsulates the Gitflow branching workflow for this repo (develop as integration branch, main as production branch). TRIGGER when the user asks to start/create a new feature, release, or hotfix branch, when asking to merge/finish a release or hotfix, or when asking to tag a release or hotfix after it has been merged. Phrases like "start a new feature", "create a release branch", "start a hotfix", "merge the release", "finish the hotfix", "tag the release" all trigger this skill.
+description: Encapsulates the Gitflow branching workflow for this repo (develop as integration branch, main as production branch). TRIGGER when the user asks to start/create a new feature, release, or hotfix branch, when asking to merge/finish a feature, release, or hotfix, or when asking to tag a release or hotfix after it has been merged. Phrases like "start a new feature", "create a release branch", "start a hotfix", "merge the feature", "finish the feature", "merge the release", "finish the hotfix", "tag the release" all trigger this skill.
 license: MIT
 metadata:
   author: Juan Pablo Drexler
   version: "1.0"
 ---
 
-Perform one Gitflow action: start a feature/release/hotfix branch, finish (open PRs for) a release/hotfix, or tag main after a release/hotfix PR has merged.
+Perform one Gitflow action: start a feature/release/hotfix branch, finish (open a PR for) a feature, finish (open PRs for) a release/hotfix, or tag main after a release/hotfix PR has merged.
 
-**Input**: The action (`start feature`, `start release`, `start hotfix`, `finish release`, `finish hotfix`, `tag release`, `tag hotfix`) plus a name/version. If the action is ambiguous from the user's request, infer it from phrasing (see TRIGGER examples above) and confirm the target name/version with the user before acting if it wasn't given explicitly.
+**Input**: The action (`start feature`, `start release`, `start hotfix`, `finish feature`, `finish release`, `finish hotfix`, `tag release`, `tag hotfix`) plus a name/version. If the action is ambiguous from the user's request, infer it from phrasing (see TRIGGER examples above) and confirm the target name/version with the user before acting if it wasn't given explicitly.
 
 ---
 
@@ -17,7 +17,7 @@ Perform one Gitflow action: start a feature/release/hotfix branch, finish (open 
 
 | Branch type | Created from | Prefix       | Finishes into      |
 |-------------|--------------|--------------|---------------------|
-| feature     | `develop`    | `feature/`   | `develop` (not automated by this skill) |
+| feature     | `develop`    | `feature/`   | `develop` via PR |
 | release     | `develop`    | `release/`   | `main` **and** `develop` via PR |
 | hotfix      | `main`       | `hotfix/`    | `main` **and** `develop` via PR |
 
@@ -33,6 +33,7 @@ Map the user's request to one of:
 - **start feature** `<name>`
 - **start release** `<version>`
 - **start hotfix** `<version>`
+- **finish feature** (operates on the current feature branch, or one named explicitly)
 - **finish release** (operates on the current release branch, or one named explicitly)
 - **finish hotfix** (operates on the current hotfix branch, or one named explicitly)
 - **tag release** `<version>` / **tag hotfix** `<version>`
@@ -51,22 +52,47 @@ Run `git status`. If there are uncommitted changes, stop and tell the user — d
 4. `git checkout -b <prefix>/<name-or-version>` where prefix is `feature`, `release`, or `hotfix`.
 5. Report the new branch name and its base. Do not push automatically — let the user decide when to push.
 
-### 3b. Finish release / Finish hotfix (open PRs)
+### 3b. Finish feature (open PR)
+
+Preconditions:
+- Current branch (or the one named explicitly) must start with `feature/`.
+- Branch must exist on the remote — if not, push it first: `git push -u origin <branch>` (confirm with the user before pushing if this is the first push of the branch).
+
+Steps:
+1. Build the PR description (see "Writing the PR description" below).
+2. `gh pr create --base develop --head <branch> --title "Feature <name>" --body "<description>"` — PR into `develop`.
+3. Report the PR URL to the user.
+
+This step **only opens the PR** — it does not merge it. Merging goes through normal GitHub review. Do not auto-merge. Feature branches never target `main` directly and are never tagged — only `release/*` and `hotfix/*` branches that land on `main` get a version tag.
+
+### 3c. Finish release / Finish hotfix (open PRs)
 
 Preconditions:
 - Current branch (or the one named explicitly) must start with `release/` or `hotfix/` matching the action.
 - Branch must exist on the remote — if not, push it first: `git push -u origin <branch>` (confirm with the user before pushing if this is the first push of the branch).
 
 Steps:
-1. `gh pr create --base main --head <branch> --title "<Release|Hotfix> <version>" --body "..."` — PR into `main`.
-2. `gh pr create --base develop --head <branch> --title "<Release|Hotfix> <version>" --body "..."` — PR into `develop`.
-3. Report both PR URLs to the user.
+1. Build the PR description (see "Writing the PR description" below) — the same description is used for both PRs since they carry the same commits.
+2. `gh pr create --base main --head <branch> --title "<Release|Hotfix> <version>" --body "<description>"` — PR into `main`.
+3. `gh pr create --base develop --head <branch> --title "<Release|Hotfix> <version>" --body "<description>"` — PR into `develop`.
+4. Report both PR URLs to the user.
 
 This step **only opens the PRs** — it does not merge them. Merging goes through normal GitHub review. Do not auto-merge.
 
 Note in the summary: once the PR into `main` is merged, run the **tag release/hotfix** action to tag `main` with the version.
 
-### 3c. Tag release / Tag hotfix
+### Writing the PR description
+
+Every PR opened by this skill needs a description detailed enough for a reviewer to understand what's actually changing, not a placeholder:
+
+1. Inspect the actual content of the change: `git log <base>..<branch> --oneline` for the commit list, and `git diff <base>..<branch> --stat` for the files touched. Read individual commit messages (and diffs, for anything non-obvious) rather than guessing from branch/file names alone.
+2. Write the PR body using this structure:
+   - **Summary** — 2-4 bullet points describing the substantive changes (what behavior changed and why, not a mechanical commit list).
+   - **Changes** — grouped by area/component if the diff spans multiple concerns (e.g. domain, UI, migrations).
+   - **Test plan** — how this was verified (tests run, manual checks) if that's discoverable from the commits; omit rather than fabricate if it isn't.
+3. Do not use a generic placeholder body like `"..."`, `"Merge <branch>"`, or the PR title repeated — the description must reflect the real diff.
+
+### 3d. Tag release / Tag hotfix
 
 This step must run **after** the PR into `main` has actually been merged — it tags the resulting commit on `main`, matching Gitflow's convention of tagging production merges.
 
@@ -85,9 +111,10 @@ This step must run **after** the PR into `main` has actually been merged — it 
 ## Guardrails
 
 - Never force-push, force-create branches over existing ones, or delete branches as part of this skill.
-- Never merge a PR automatically — "finish release/hotfix" only creates the PRs; merging is a human review step.
+- Never merge a PR automatically — "finish feature/release/hotfix" only creates the PR(s); merging is a human review step.
+- Never open a PR with a placeholder or generic body — always derive the description from the actual commits/diff on the branch, per "Writing the PR description" above.
 - Never tag `main` without first confirming (via `gh pr list --state merged`) that the corresponding release/hotfix PR into `main` has actually merged.
 - Never tag without explicit user confirmation immediately before the `git push origin <tag>` — pushing a tag is visible to the whole team and awkward to undo.
 - If the working tree has uncommitted changes at the start of any action, stop and report — never stash or discard automatically.
 - If `git pull` on the base branch doesn't fast-forward cleanly, stop and report — never force-merge or rebase automatically.
-- `feature/*` branches only ever merge back into `develop`, never into `main` directly, and this skill does not automate that merge — feature integration typically happens via normal PR review into `develop`, outside this skill's "finish" actions.
+- `feature/*` branches only ever merge back into `develop`, never into `main` directly, and are never tagged — only `release/*` and `hotfix/*` branches that land on `main` get a version tag.


### PR DESCRIPTION
## Summary
- Adds a new `gitflow` skill that encapsulates this repo's Gitflow branching conventions (develop as integration branch, main as production branch).
- Wires the `feature-development` skill to delegate to `gitflow` instead of handling branch operations itself.
- Adds a `finish-feature` action (opens a PR from a `feature/*` branch into `develop`) alongside the existing start/finish/tag actions for release and hotfix branches, and requires every PR body to be derived from the actual commits/diff rather than a placeholder.
- Lets `finish feature` infer the feature name from the current branch name (stripping the `feature/` prefix) when none is given explicitly, avoiding an unnecessary prompt.

## Changes
- `.claude/skills/gitflow/SKILL.md` — new skill: branch/tag conventions table, start/finish/tag steps for feature/release/hotfix, PR description guardrails, and the new finish-feature action with branch-name inference.
- `.claude/skills/feature-development/SKILL.md` — updated to invoke the `gitflow` skill for branch lifecycle steps instead of duplicating that logic.

## Test plan
- N/A — documentation/skill-definition change only, no application code affected.