### PR TITLE
Feature github-cleanup

### DIFF
--- a/.claude/skills/gitflow/SKILL.md
+++ b/.claude/skills/gitflow/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: gitflow
-description: Encapsulates the Gitflow branching workflow for this repo (develop as integration branch, main as production branch). TRIGGER when the user asks to start/create a new feature, release, or hotfix branch, when asking to merge/finish a feature, release, or hotfix, or when asking to tag a release or hotfix after it has been merged. Phrases like "start a new feature", "create a release branch", "start a hotfix", "merge the feature", "finish the feature", "merge the release", "finish the hotfix", "tag the release" all trigger this skill.
+description: Encapsulates the Gitflow branching workflow for this repo (develop as integration branch, main as production branch). TRIGGER when the user asks to start/create a new feature, release, or hotfix branch, when asking to merge/finish a feature, release, or hotfix, when asking to tag a release or hotfix after it has been merged, or when asking to clean up/delete already-merged branches. Phrases like "start a new feature", "create a release branch", "start a hotfix", "merge the feature", "finish the feature", "merge the release", "finish the hotfix", "tag the release", "clean up the branches", "delete merged branches" all trigger this skill.
 license: MIT
 metadata:
   author: Juan Pablo Drexler
   version: "1.0"
 ---
 
-Perform one Gitflow action: start a feature/release/hotfix branch, finish (open a PR for) a feature, finish (open PRs for) a release/hotfix, or tag main after a release/hotfix PR has merged.
+Perform one Gitflow action: start a feature/release/hotfix branch, finish (open a PR for) a feature, finish (open PRs for) a release/hotfix, tag main after a release/hotfix PR has merged, or clean up already-merged feature/release/hotfix branches.
 
-**Input**: The action (`start feature`, `start release`, `start hotfix`, `finish feature`, `finish release`, `finish hotfix`, `tag release`, `tag hotfix`) plus a name/version. If the action is ambiguous from the user's request, infer it from phrasing (see TRIGGER examples above) and confirm the target name/version with the user before acting if it wasn't given explicitly.
+**Input**: The action (`start feature`, `start release`, `start hotfix`, `finish feature`, `finish release`, `finish hotfix`, `tag release`, `tag hotfix`, `cleanup branches`) plus a name/version (not needed for `cleanup branches`). If the action is ambiguous from the user's request, infer it from phrasing (see TRIGGER examples above) and confirm the target name/version with the user before acting if it wasn't given explicitly.
 
 ---
 
@@ -37,12 +37,13 @@ Map the user's request to one of:
 - **finish release** (operates on the current release branch, or one named explicitly)
 - **finish hotfix** (operates on the current hotfix branch, or one named explicitly)
 - **tag release** `<version>` / **tag hotfix** `<version>`
+- **cleanup branches** (no name/version — operates across all `feature/*`, `release/*`, `hotfix/*` branches in the repo)
 
 If the name/version wasn't given and can't be inferred from the current branch, ask for it. For **finish feature** specifically, if no name is given explicitly, infer it from the current branch name by stripping the `feature/` prefix (e.g. current branch `feature/skills-gitflow` → name `skills-gitflow`) — no need to ask the user in this case.
 
 ### 2. Check working tree state
 
-Run `git status`. If there are uncommitted changes, stop and tell the user — do not stash or discard automatically.
+Run `git status`. If there are uncommitted changes, stop and tell the user — do not stash or discard automatically. (For **cleanup branches**, this only matters if the current branch is itself a deletion candidate — see 3e.)
 
 ### 3a. Start feature / release / hotfix
 
@@ -106,11 +107,31 @@ This step must run **after** the PR into `main` has actually been merged — it 
 8. `git push origin v<version>`
 9. Report the pushed tag.
 
+### 3e. Cleanup branches
+
+Finds `feature/*`, `release/*`, and `hotfix/*` branches that have already been merged, and deletes only the ones the user explicitly confirms — never speculatively, never with `-D`/`--force`.
+
+1. `git fetch origin --prune` — sync remote-tracking refs so branches already deleted on GitHub (e.g. auto-deleted on merge) aren't listed as candidates.
+2. Enumerate candidates: local branches via `git branch --list 'feature/*' 'release/*' 'hotfix/*' --format='%(refname:short)'`, remote via `git branch -r --list 'origin/feature/*' 'origin/release/*' 'origin/hotfix/*' --format='%(refname:short)'` (strip the `origin/` prefix). Union the two lists by name — note whether each exists locally, remotely, or both.
+3. For each candidate branch, determine merged status with a direct check (per the repo-state guardrail below — never infer this from timing or narrative):
+   - `feature/<name>`: merged if `gh pr list --state merged --head <branch> --base develop --json number,mergedAt` returns at least one result.
+   - `release/<version>` or `hotfix/<version>`: merged if **both** hold — `gh pr list --state merged --head <branch> --base main --json number,mergedAt` returns a result, **and** `git merge-base --is-ancestor origin/<branch> origin/develop` exits 0 (confirms `develop` also has the commits, whether via its own merged PR or because `develop` already contained them).
+   - A branch with no merged PR found this way is **not** a candidate — leave it alone and don't list it, even if it looks stale. This only recognizes merges that went through a PR; branches merged some other way won't be flagged, which is the safe direction to be wrong in.
+4. If no merged branches are found, report that and stop — nothing to clean up.
+5. List every merged candidate to the user: branch name, type (feature/release/hotfix), and where it exists (local/remote/both). If there's more than one, ask whether to delete **all** of them or **specific** ones (and if specific, which — let the user pick from the list). If there's exactly one, still confirm before deleting it.
+6. For whichever branches the user selected, ask whether to delete the **local** branch, the **remote** branch, or **both** — per branch if they exist in different places, or once for the whole batch if that's simpler for the user to answer.
+7. Do one final explicit confirmation of exactly what's about to be deleted (branch names × local/remote) before running anything — deletion of a shared remote branch is hard to reverse.
+8. Delete only what was confirmed:
+   - Local: `git branch -d <branch>` — never `-D`. If the branch to delete is the current branch, `git checkout` its base first (`develop` for feature/release, `main` for hotfix) before deleting.
+   - Remote: `git push origin --delete <branch>`. If the ref is already gone (common — GitHub auto-deletes on merge), report that rather than treating it as an error.
+9. Report exactly what was deleted (and what was already gone / skipped).
+
 ---
 
 ## Guardrails
 
-- Never force-push, force-create branches over existing ones, or delete branches as part of this skill.
+- Never force-push, force-create branches over existing ones, or force-delete a branch (`git branch -D`, `git push --force`). The only sanctioned branch deletion is the **Cleanup branches** action, and only for branches confirmed merged per its steps — never delete speculatively.
+- Cleanup branches never deletes anything without the user explicitly confirming: which branches (from the listed candidates), and for each, whether to delete local, remote, or both. Do not skip either confirmation step or bundle them into a single implicit approval.
 - Never merge a PR automatically — "finish feature/release/hotfix" only creates the PR(s); merging is a human review step.
 - Never open a PR with a placeholder or generic body — always derive the description from the actual commits/diff on the branch, per "Writing the PR description" above.
 - Never tag `main` without first confirming (via `gh pr list --state merged`) that the corresponding release/hotfix PR into `main` has actually merged.


### PR DESCRIPTION
## Summary
- Adds a **Cleanup branches** action to the `gitflow` skill: finds `feature/*`, `release/*`, and `hotfix/*` branches that have already been merged and offers to delete them.
- Merge status is verified directly (never inferred from timing/narrative), matching the skill's existing repo-state guardrails: `gh pr list --state merged` for the feature→develop and release/hotfix→main PRs, plus a `git merge-base --is-ancestor` check confirming `develop` also has a release/hotfix branch's commits.
- Deletion is always opt-in and never forced: candidates are listed to the user first, who picks all-or-specific branches, then chooses local/remote/both per selection, then gives one final explicit confirmation before anything is deleted. `git branch -d` and `git push origin --delete` are used — never `-D`/`--force`.
- Reconciles the previous blanket "never delete branches" guardrail with this new sanctioned deletion path, and updates the skill's trigger phrases/description to recognize "clean up the branches" / "delete merged branches" requests.

## Changes
- `.claude/skills/gitflow/SKILL.md`:
  - New `cleanup branches` action added to the action list and input description.
  - New `### 3e. Cleanup branches` section with the full detection → listing → selection → scope → confirmation → deletion → report flow.
  - Guardrails updated: the old "never delete branches" rule now carves out Cleanup branches as the only sanctioned deletion path (still no force-delete), plus a new guardrail requiring explicit user confirmation at both the branch-selection and local/remote/both steps.

## Test plan
- N/A — skill-definition change only, no application code affected.