### PR TITLE
Migrate frontend to zoneless change detection

### DIFF
--- a/JPPhotoManagerWeb/frontend/angular.json
+++ b/JPPhotoManagerWeb/frontend/angular.json
@@ -21,7 +21,7 @@
             "outputPath": "dist/jp-photo-manager-ui",
             "index": "src/index.html",
             "browser": "src/main.ts",
-            "polyfills": ["zone.js"],
+            "polyfills": [],
             "tsConfig": "tsconfig.app.json",
             "assets": [
               {
@@ -72,7 +72,7 @@
         "test": {
           "builder": "@angular/build:karma",
           "options": {
-            "polyfills": ["zone.js", "zone.js/testing"],
+            "polyfills": [],
             "tsConfig": "tsconfig.spec.json",
             "assets": [
               {

--- a/JPPhotoManagerWeb/frontend/cypress/support/component.ts
+++ b/JPPhotoManagerWeb/frontend/cypress/support/component.ts
@@ -1,6 +1,5 @@
 import '@cypress/code-coverage/support';
-import { mount, MountConfig } from 'cypress/angular';
-import { provideZoneChangeDetection } from '@angular/core';
+import { mount } from 'cypress/angular';
 export { MockEventSource } from './mock-event-source';
 
 declare global {
@@ -11,23 +10,4 @@ declare global {
   }
 }
 
-// cy.mount() creates each fixture through its own isolated TestBed module,
-// which doesn't inherit app.config.ts's providers - so without this, Angular
-// 22's now-zoneless-by-default TestBed bootstrap made component fixtures
-// behave zoneless in tests even though the real app still boots zone.js-based
-// (provideZoneChangeDetection in app.config.ts, zone.js in angular.json's
-// polyfills - a deliberate choice, not an oversight, since this app has no
-// OnPush components yet). That mismatch surfaced as spurious NG0100
-// ExpressionChangedAfterItHasBeenCheckedError failures in tests that mutate
-// component state from outside Angular's normal event handlers (SSE message
-// handlers, subscribe callbacks after a delete action) - zoneless's stricter
-// checkNoChanges pass doesn't get the zone-triggered blanket re-check that
-// papered over the same timing gap under zone.js. Providing this here once,
-// globally, keeps every component test's change detection consistent with
-// the real app instead of duplicating it into all 40+ *.cy.ts files.
-Cypress.Commands.add('mount', (component, config?: MountConfig<unknown>) =>
-  mount(component, {
-    ...config,
-    providers: [provideZoneChangeDetection({ eventCoalescing: true }), ...(config?.providers ?? [])],
-  }),
-);
+Cypress.Commands.add('mount', mount);

--- a/JPPhotoManagerWeb/frontend/package-lock.json
+++ b/JPPhotoManagerWeb/frontend/package-lock.json
@@ -22,8 +22,7 @@
         "@swimlane/ngx-charts": "^24.0.0-alpha.1",
         "idb": "^8.0.3",
         "rxjs": "~7.8.0",
-        "tslib": "^2.3.0",
-        "zone.js": "~0.15.0"
+        "tslib": "^2.3.0"
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^22.1.1",
@@ -21561,11 +21560,6 @@
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }
-    },
-    "node_modules/zone.js": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
-      "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w=="
     }
   }
 }

--- a/JPPhotoManagerWeb/frontend/package-lock.json
+++ b/JPPhotoManagerWeb/frontend/package-lock.json
@@ -45,7 +45,8 @@
         "istanbul-lib-instrument": "^6.0.3",
         "start-server-and-test": "^3.0.12",
         "typescript": "~6.0.3",
-        "typescript-eslint": "^8.67.0"
+        "typescript-eslint": "^8.67.0",
+        "zone.js": "^0.15.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -21560,6 +21561,13 @@
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }
+    },
+    "node_modules/zone.js": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
+      "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/JPPhotoManagerWeb/frontend/package.json
+++ b/JPPhotoManagerWeb/frontend/package.json
@@ -56,6 +56,7 @@
     "istanbul-lib-instrument": "^6.0.3",
     "start-server-and-test": "^3.0.12",
     "typescript": "~6.0.3",
-    "typescript-eslint": "^8.67.0"
+    "typescript-eslint": "^8.67.0",
+    "zone.js": "^0.15.1"
   }
 }

--- a/JPPhotoManagerWeb/frontend/package.json
+++ b/JPPhotoManagerWeb/frontend/package.json
@@ -33,8 +33,7 @@
     "@swimlane/ngx-charts": "^24.0.0-alpha.1",
     "idb": "^8.0.3",
     "rxjs": "~7.8.0",
-    "tslib": "^2.3.0",
-    "zone.js": "~0.15.0"
+    "tslib": "^2.3.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^22.1.1",

--- a/JPPhotoManagerWeb/frontend/src/app/app.component.html
+++ b/JPPhotoManagerWeb/frontend/src/app/app.component.html
@@ -3,7 +3,7 @@
   <span style="margin-left: 8px;">JP Photo Manager</span>
   <span style="flex: 1"></span>
   @if (isLoggedIn) {
-    @if (isMobile) {
+    @if (isMobile()) {
       <button mat-icon-button [matMenuTriggerFor]="navMenu" aria-label="Open navigation">
         <mat-icon>menu</mat-icon>
       </button>
@@ -33,7 +33,7 @@
         <button mat-menu-item (click)="openAbout()"><mat-icon>info</mat-icon> About</button>
       </mat-menu>
     }
-    @if (!isMobile) {
+    @if (!isMobile()) {
       <a mat-button routerLink="/home" routerLinkActive="active">
         <mat-icon>home</mat-icon> Home
       </a>
@@ -102,10 +102,10 @@
 
 @if (isLoggedIn) {
   <app-catalog-progress-footer
-    [state]="catalogState"
-    [percentCompleted]="catalogPercentCompleted"
-    [currentStatusText]="catalogStatusText"
-    [lastCompletedAt]="catalogLastCompletedAt"
+    [state]="catalogState()"
+    [percentCompleted]="catalogPercentCompleted()"
+    [currentStatusText]="catalogStatusText()"
+    [lastCompletedAt]="catalogLastCompletedAt()"
     (reconnect)="connectCatalog()"
   />
 }

--- a/JPPhotoManagerWeb/frontend/src/app/app.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe } from '@angular/common';
-import { Component, DoCheck, inject, OnDestroy, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, DoCheck, inject, OnDestroy, OnInit, ChangeDetectionStrategy, signal } from '@angular/core';
 import { Router, RouterOutlet, RouterLink, RouterLinkActive } from '@angular/router';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
@@ -45,12 +45,12 @@ import { CatalogProgressFooterComponent } from './shared/components/catalog-prog
     CatalogProgressFooterComponent,
   ],
   templateUrl: './app.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './app.component.scss'
 })
 export class AppComponent implements OnInit, OnDestroy, DoCheck {
   title = 'JP Photo Manager';
-  isMobile = false;
+  readonly isMobile = signal(false);
   private bpSub!: Subscription;
   private onlineListener = () => this.replayPendingMutations();
 
@@ -61,10 +61,10 @@ export class AppComponent implements OnInit, OnDestroy, DoCheck {
   readonly isDark$ = this.themeService.isDark$;
   readonly accentColor$ = this.themeService.accentColor$;
 
-  catalogState: CatalogState = 'idle';
-  catalogPercentCompleted = 0;
-  catalogStatusText = '';
-  catalogLastCompletedAt: Date | null = null;
+  readonly catalogState = signal<CatalogState>('idle');
+  readonly catalogPercentCompleted = signal(0);
+  readonly catalogStatusText = signal('');
+  readonly catalogLastCompletedAt = signal<Date | null>(null);
 
   private catalogEventSource?: EventSource;
   private wasLoggedIn = false;
@@ -82,7 +82,7 @@ export class AppComponent implements OnInit, OnDestroy, DoCheck {
   ngOnInit(): void {
     this.themeService.init();
     this.bpSub = this.breakpointObserver.observe([Breakpoints.Handset]).subscribe(result => {
-      this.isMobile = result.matches;
+      this.isMobile.set(result.matches);
     });
     window.addEventListener('online', this.onlineListener);
     if (navigator.onLine) {
@@ -108,31 +108,31 @@ export class AppComponent implements OnInit, OnDestroy, DoCheck {
 
   connectCatalog(): void {
     this.disconnectCatalog();
-    this.catalogState = 'idle';
-    this.catalogPercentCompleted = 0;
-    this.catalogStatusText = '';
+    this.catalogState.set('idle');
+    this.catalogPercentCompleted.set(0);
+    this.catalogStatusText.set('');
 
     this.catalogEventSource = this.assetService.observeCatalog();
 
     this.catalogEventSource.addEventListener('catalog', (event: MessageEvent) => {
-      this.catalogState = 'running';
+      this.catalogState.set('running');
       const notification = JSON.parse(event.data as string) as CatalogNotification;
-      this.catalogPercentCompleted = notification.percentCompleted;
+      this.catalogPercentCompleted.set(notification.percentCompleted);
       if (notification.folderPath) {
-        this.catalogStatusText = notification.folderPath;
+        this.catalogStatusText.set(notification.folderPath);
       } else if (notification.asset?.fileName) {
-        this.catalogStatusText = notification.asset.fileName;
+        this.catalogStatusText.set(notification.asset.fileName);
       }
     });
 
     this.catalogEventSource.addEventListener('catalog-done', () => {
-      this.catalogState = 'idle';
-      this.catalogLastCompletedAt = new Date();
+      this.catalogState.set('idle');
+      this.catalogLastCompletedAt.set(new Date());
     });
 
     this.catalogEventSource.onerror = () => {
-      if (this.catalogState === 'running') {
-        this.catalogState = 'idle';
+      if (this.catalogState() === 'running') {
+        this.catalogState.set('idle');
       }
     };
   }

--- a/JPPhotoManagerWeb/frontend/src/app/app.config.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/app.config.ts
@@ -1,4 +1,4 @@
-import { ApplicationConfig, ErrorHandler, provideZoneChangeDetection, isDevMode } from '@angular/core';
+import { ApplicationConfig, ErrorHandler, provideZonelessChangeDetection, isDevMode } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient, withInterceptors, withXhr } from '@angular/common/http';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
@@ -9,7 +9,7 @@ import { provideServiceWorker } from '@angular/service-worker';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideZonelessChangeDetection(),
     provideRouter(routes),
     provideHttpClient(withXhr(), withInterceptors([authInterceptor])),
     provideAnimationsAsync(),

--- a/JPPhotoManagerWeb/frontend/src/app/features/admin/users/user-admin.component.html
+++ b/JPPhotoManagerWeb/frontend/src/app/features/admin/users/user-admin.component.html
@@ -4,8 +4,8 @@
       <mat-card-title>User Administration</mat-card-title>
     </mat-card-header>
     <mat-card-content>
-      @if (errorMessage) {
-        <p class="error-message">{{ errorMessage }}</p>
+      @if (errorMessage()) {
+        <p class="error-message">{{ errorMessage() }}</p>
       }
 
       <div class="toolbar">
@@ -30,7 +30,7 @@
         </form>
       }
 
-      <table mat-table [dataSource]="users" class="users-table">
+      <table mat-table [dataSource]="users()" class="users-table">
         <ng-container matColumnDef="username">
           <th mat-header-cell *matHeaderCellDef>Username</th>
           <td mat-cell *matCellDef="let user">{{ user.username }}</td>
@@ -44,7 +44,7 @@
         <ng-container matColumnDef="actions">
           <th mat-header-cell *matHeaderCellDef>Actions</th>
           <td mat-cell *matCellDef="let user">
-            @if (editingPasswordId === user.id) {
+            @if (editingPasswordId() === user.id) {
               <form [formGroup]="passwordForm" (ngSubmit)="submitPasswordChange(user.id)" class="inline-form">
                 <mat-form-field appearance="outline" class="password-field">
                   <mat-label>New Password</mat-label>
@@ -52,7 +52,7 @@
                 </mat-form-field>
                 <app-password-strength [password]="changePasswordValue" />
                 <button mat-raised-button color="primary" type="submit" size="small">Save</button>
-                <button mat-button type="button" (click)="editingPasswordId = null">Cancel</button>
+                <button mat-button type="button" (click)="editingPasswordId.set(null)">Cancel</button>
               </form>
             } @else {
               <button mat-icon-button title="Change password" (click)="startEditPassword(user.id)">
@@ -69,7 +69,7 @@
         <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
       </table>
 
-      @if (users.length === 0) {
+      @if (users().length === 0) {
         <p class="no-users">No users found.</p>
       }
     </mat-card-content>

--- a/JPPhotoManagerWeb/frontend/src/app/features/admin/users/user-admin.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/admin/users/user-admin.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatTableModule } from '@angular/material/table';
@@ -20,15 +20,15 @@ import { PasswordStrengthComponent } from '../../../shared/components/password-s
             MatFormFieldModule, MatInputModule, MatIconModule, MatCardModule,
             PasswordStrengthComponent],
   templateUrl: './user-admin.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './user-admin.component.scss'
 })
 export class UserAdminComponent implements OnInit {
-  users: UserAdmin[] = [];
+  readonly users = signal<UserAdmin[]>([]);
   displayedColumns = ['username', 'createdAt', 'actions'];
-  errorMessage: string | null = null;
+  readonly errorMessage = signal<string | null>(null);
   showAddForm = false;
-  editingPasswordId: string | null = null;
+  readonly editingPasswordId = signal<string | null>(null);
 
   addForm = this.fb.nonNullable.group({
     username: ['', Validators.required],
@@ -59,8 +59,8 @@ export class UserAdminComponent implements OnInit {
 
   loadUsers(): void {
     this.userAdminService.getUsers().subscribe({
-      next: users => (this.users = users),
-      error: () => (this.errorMessage = 'Failed to load users.')
+      next: users => this.users.set(users),
+      error: () => this.errorMessage.set('Failed to load users.')
     });
   }
 
@@ -69,17 +69,17 @@ export class UserAdminComponent implements OnInit {
     const { username, password } = this.addForm.getRawValue();
     this.userAdminService.createUser(username, password).subscribe({
       next: user => {
-        this.users = [...this.users, user];
+        this.users.update(list => [...list, user]);
         this.addForm.reset();
         this.showAddForm = false;
-        this.errorMessage = null;
+        this.errorMessage.set(null);
       },
-      error: () => (this.errorMessage = 'Failed to create user. Username may already exist.')
+      error: () => this.errorMessage.set('Failed to create user. Username may already exist.')
     });
   }
 
   startEditPassword(id: string): void {
-    this.editingPasswordId = id;
+    this.editingPasswordId.set(id);
     this.passwordForm.reset();
   }
 
@@ -88,10 +88,10 @@ export class UserAdminComponent implements OnInit {
     const { password } = this.passwordForm.getRawValue();
     this.userAdminService.updatePassword(id, password).subscribe({
       next: () => {
-        this.editingPasswordId = null;
-        this.errorMessage = null;
+        this.editingPasswordId.set(null);
+        this.errorMessage.set(null);
       },
-      error: () => (this.errorMessage = 'Failed to update password.')
+      error: () => this.errorMessage.set('Failed to update password.')
     });
   }
 
@@ -104,10 +104,10 @@ export class UserAdminComponent implements OnInit {
       if (!confirmed) return;
       this.userAdminService.deleteUser(id).subscribe({
         next: () => {
-          this.users = this.users.filter(u => u.id !== id);
-          this.errorMessage = null;
+          this.users.update(list => list.filter(u => u.id !== id));
+          this.errorMessage.set(null);
         },
-        error: () => (this.errorMessage = 'Failed to delete user.')
+        error: () => this.errorMessage.set('Failed to delete user.')
       });
     });
   }

--- a/JPPhotoManagerWeb/frontend/src/app/features/albums/album-detail/album-detail.component.cy.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/albums/album-detail/album-detail.component.cy.ts
@@ -85,7 +85,7 @@ describe('AlbumDetailComponent', () => {
     const dialogRef = { afterClosed: () => of(updatedFilter) };
     mountDetail(smartAlbum).then(({ component, serviceStub }) => {
       component.albumId = ALBUM_ID;
-      component.album = smartAlbum;
+      component.album.set(smartAlbum);
       (component as unknown as { dialog: MatDialog }).dialog = { open: () => dialogRef } as unknown as MatDialog;
       component.openEditFilterDialog();
       cy.wrap(serviceStub.updateAlbum).should('have.been.calledWith', ALBUM_ID, {

--- a/JPPhotoManagerWeb/frontend/src/app/features/albums/album-detail/album-detail.component.html
+++ b/JPPhotoManagerWeb/frontend/src/app/features/albums/album-detail/album-detail.component.html
@@ -1,4 +1,4 @@
-@if (album) {
+@if (album(); as album) {
   <mat-toolbar>
     <button mat-icon-button routerLink="/albums" title="Back to albums">
       <mat-icon>arrow_back</mat-icon>
@@ -37,11 +37,11 @@
 
   @if (totalPages > 1) {
     <div class="pagination">
-      <button mat-icon-button [disabled]="currentPage === 0" (click)="loadPage(currentPage - 1)">
+      <button mat-icon-button [disabled]="currentPage() === 0" (click)="loadPage(currentPage() - 1)">
         <mat-icon>chevron_left</mat-icon>
       </button>
-      <span>{{ currentPage + 1 }} / {{ totalPages }}</span>
-      <button mat-icon-button [disabled]="currentPage >= totalPages - 1" (click)="loadPage(currentPage + 1)">
+      <span>{{ currentPage() + 1 }} / {{ totalPages }}</span>
+      <button mat-icon-button [disabled]="currentPage() >= totalPages - 1" (click)="loadPage(currentPage() + 1)">
         <mat-icon>chevron_right</mat-icon>
       </button>
     </div>

--- a/JPPhotoManagerWeb/frontend/src/app/features/albums/album-detail/album-detail.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/albums/album-detail/album-detail.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, signal } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
@@ -23,14 +23,14 @@ import { EditAlbumFilterDialogComponent } from './edit-album-filter-dialog.compo
     ThumbnailComponent
   ],
   templateUrl: './album-detail.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './album-detail.component.scss'
 })
 export class AlbumDetailComponent implements OnInit {
 
-  album: Album | null = null;
+  readonly album = signal<Album | null>(null);
   albumId = 0;
-  currentPage = 0;
+  readonly currentPage = signal(0);
 
   constructor(
     private route: ActivatedRoute,
@@ -46,9 +46,9 @@ export class AlbumDetailComponent implements OnInit {
   }
 
   loadPage(page: number): void {
-    this.currentPage = page;
+    this.currentPage.set(page);
     this.albumService.getAlbum(this.albumId, page).subscribe({
-      next: album => (this.album = album),
+      next: album => this.album.set(album),
       error: () => {
         this.snackBar.open('Failed to load album', 'Dismiss', { duration: 3000 });
         this.router.navigate(['/albums']);
@@ -57,11 +57,11 @@ export class AlbumDetailComponent implements OnInit {
   }
 
   isSmartAlbum(): boolean {
-    return this.album?.filterJson != null;
+    return this.album()?.filterJson != null;
   }
 
   filterSummary(): string {
-    const filter = this.album?.filterJson;
+    const filter = this.album()?.filterJson;
     if (!filter) return '';
     const parts: string[] = [];
     if (filter.search) parts.push(`Search: ${filter.search}`);
@@ -72,7 +72,7 @@ export class AlbumDetailComponent implements OnInit {
   }
 
   openEditFilterDialog(): void {
-    const album = this.album;
+    const album = this.album();
     if (!album) return;
 
     const ref = this.dialog.open(EditAlbumFilterDialogComponent, {
@@ -95,13 +95,13 @@ export class AlbumDetailComponent implements OnInit {
     this.albumService.removeAssets(this.albumId, [assetId]).subscribe({
       next: () => {
         this.snackBar.open('Removed from album', undefined, { duration: 2000 });
-        this.loadPage(this.currentPage);
+        this.loadPage(this.currentPage());
       },
       error: () => this.snackBar.open('Failed to remove asset', 'Dismiss', { duration: 3000 })
     });
   }
 
   get totalPages(): number {
-    return this.album?.assets.totalPages ?? 0;
+    return this.album()?.assets.totalPages ?? 0;
   }
 }

--- a/JPPhotoManagerWeb/frontend/src/app/features/albums/album-detail/edit-album-filter-dialog.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/albums/album-detail/edit-album-filter-dialog.component.ts
@@ -58,7 +58,7 @@ import { AlbumFilterJson, EditAlbumFilterDialogData } from '../../../core/models
       <button mat-raised-button color="primary" (click)="confirm()">Save</button>
     </mat-dialog-actions>
   `,
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [`
     .filter-fields { display: flex; flex-direction: column; gap: 8px; min-width: 320px; }
     .filter-rating { display: flex; align-items: center; gap: 2px; }

--- a/JPPhotoManagerWeb/frontend/src/app/features/albums/albums.component.html
+++ b/JPPhotoManagerWeb/frontend/src/app/features/albums/albums.component.html
@@ -50,7 +50,7 @@
 }
 
 <div class="albums-grid">
-  @for (album of albums; track album.albumId) {
+  @for (album of albums(); track album.albumId) {
     <mat-card class="album-card">
       <mat-card-header>
         <mat-card-title>
@@ -74,7 +74,7 @@
       </mat-card-actions>
     </mat-card>
   }
-  @if (albums.length === 0) {
+  @if (albums().length === 0) {
     <div class="empty-state">No albums yet. Create one to get started.</div>
   }
 </div>

--- a/JPPhotoManagerWeb/frontend/src/app/features/albums/albums.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/albums/albums.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { MatToolbarModule } from '@angular/material/toolbar';
@@ -35,12 +35,12 @@ import { AlbumSummary, AlbumFilterJson } from '../../core/models/album.model';
     MatNativeDateModule
   ],
   templateUrl: './albums.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './albums.component.scss'
 })
 export class AlbumsComponent implements OnInit {
 
-  albums: AlbumSummary[] = [];
+  readonly albums = signal<AlbumSummary[]>([]);
   showCreateForm = false;
   newAlbumName = '';
   makeSmartAlbum = false;
@@ -56,7 +56,7 @@ export class AlbumsComponent implements OnInit {
 
   ngOnInit(): void {
     this.albumService.getAlbums().subscribe({
-      next: albums => (this.albums = albums),
+      next: albums => this.albums.set(albums),
       error: () => this.snackBar.open('Failed to load albums', 'Dismiss', { duration: 3000 })
     });
   }
@@ -90,7 +90,7 @@ export class AlbumsComponent implements OnInit {
     }
     this.albumService.createAlbum({ name: name.trim(), filterJson }).subscribe({
       next: album => {
-        this.albums = [...this.albums, album];
+        this.albums.update(list => [...list, album]);
         this.newAlbumName = '';
         this.showCreateForm = false;
         this.makeSmartAlbum = false;
@@ -107,7 +107,7 @@ export class AlbumsComponent implements OnInit {
   deleteAlbum(album: AlbumSummary): void {
     this.albumService.deleteAlbum(album.albumId).subscribe({
       next: () => {
-        this.albums = this.albums.filter(a => a.albumId !== album.albumId);
+        this.albums.update(list => list.filter(a => a.albumId !== album.albumId));
         this.snackBar.open('Album deleted', undefined, { duration: 2000 });
       },
       error: () => this.snackBar.open('Failed to delete album', 'Dismiss', { duration: 3000 })

--- a/JPPhotoManagerWeb/frontend/src/app/features/analytics/analytics.component.html
+++ b/JPPhotoManagerWeb/frontend/src/app/features/analytics/analytics.component.html
@@ -1,16 +1,16 @@
 <div class="analytics-container">
-  @if (loading) {
+  @if (loading()) {
     <div class="analytics-spinner">
       <mat-spinner />
     </div>
-  } @else if (error) {
+  } @else if (error()) {
     <mat-card class="analytics-error">
       <mat-card-content>
         <mat-icon color="warn">error</mat-icon>
         <p>Failed to load analytics data. Please try again later.</p>
       </mat-card-content>
     </mat-card>
-  } @else if (data) {
+  } @else if (data()) {
     <div class="analytics-grid">
       <mat-card>
         <mat-card-header>
@@ -18,7 +18,7 @@
         </mat-card-header>
         <mat-card-content>
           <ngx-charts-tree-map
-            [results]="folderStorageSeries"
+            [results]="folderStorageSeries()"
           />
         </mat-card-content>
       </mat-card>
@@ -29,7 +29,7 @@
         </mat-card-header>
         <mat-card-content>
           <ngx-charts-pie-chart
-            [results]="formatSeries"
+            [results]="formatSeries()"
             [legend]="true"
           />
         </mat-card-content>
@@ -41,7 +41,7 @@
         </mat-card-header>
         <mat-card-content>
           <ngx-charts-bar-vertical
-            [results]="photosPerMonthSeries"
+            [results]="photosPerMonthSeries()"
             [xAxisLabel]="'Month'"
             [yAxisLabel]="'Count'"
             [showXAxisLabel]="true"
@@ -58,7 +58,7 @@
         </mat-card-header>
         <mat-card-content>
           <ngx-charts-bar-vertical
-            [results]="ratingSeriesBarData"
+            [results]="ratingSeriesBarData()"
             [xAxisLabel]="'Stars'"
             [yAxisLabel]="'Count'"
             [showXAxisLabel]="true"

--- a/JPPhotoManagerWeb/frontend/src/app/features/analytics/analytics.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/analytics/analytics.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, signal } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatIconModule } from '@angular/material/icon';
@@ -18,43 +18,43 @@ import { AnalyticsData, ChartEntry } from '../../core/models/analytics.model';
     BarChartModule,
   ],
   templateUrl: './analytics.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './analytics.component.scss',
 })
 export class AnalyticsComponent implements OnInit {
-  data: AnalyticsData | null = null;
-  loading = true;
-  error = false;
+  readonly data = signal<AnalyticsData | null>(null);
+  readonly loading = signal(true);
+  readonly error = signal(false);
 
-  folderStorageSeries: ChartEntry[] = [];
-  formatSeries: ChartEntry[] = [];
-  photosPerMonthSeries: ChartEntry[] = [];
-  ratingSeriesBarData: ChartEntry[] = [];
+  readonly folderStorageSeries = signal<ChartEntry[]>([]);
+  readonly formatSeries = signal<ChartEntry[]>([]);
+  readonly photosPerMonthSeries = signal<ChartEntry[]>([]);
+  readonly ratingSeriesBarData = signal<ChartEntry[]>([]);
 
   constructor(private readonly analyticsService: AnalyticsService) {}
 
   ngOnInit(): void {
     this.analyticsService.getAnalytics().subscribe({
       next: (d) => {
-        this.data = d;
-        this.folderStorageSeries = d.folderStorage.map(e => ({
+        this.data.set(d);
+        this.folderStorageSeries.set(d.folderStorage.map(e => ({
           name: e.folderPath,
           value: e.bytes,
-        }));
-        this.formatSeries = d.formatDistribution.map(e => ({
+        })));
+        this.formatSeries.set(d.formatDistribution.map(e => ({
           name: e.extension,
           value: e.count,
-        }));
-        this.photosPerMonthSeries = d.photosPerMonth.map(e => ({ name: e.month, value: e.count }));
-        this.ratingSeriesBarData = d.ratingDistribution.map(e => ({
+        })));
+        this.photosPerMonthSeries.set(d.photosPerMonth.map(e => ({ name: e.month, value: e.count })));
+        this.ratingSeriesBarData.set(d.ratingDistribution.map(e => ({
           name: String(e.rating),
           value: e.count,
-        }));
-        this.loading = false;
+        })));
+        this.loading.set(false);
       },
       error: () => {
-        this.error = true;
-        this.loading = false;
+        this.error.set(true);
+        this.loading.set(false);
       },
     });
   }

--- a/JPPhotoManagerWeb/frontend/src/app/features/audio-player/audio-player.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/audio-player/audio-player.component.ts
@@ -8,7 +8,7 @@ import { MediaPlayerService } from '../../core/services/media-player.service';
   standalone: true,
   imports: [MatButtonModule, MatIconModule],
   templateUrl: './audio-player.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './audio-player.component.scss',
 })
 export class AudioPlayerComponent {

--- a/JPPhotoManagerWeb/frontend/src/app/features/auth/login/login.component.cy.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/auth/login/login.component.cy.ts
@@ -5,7 +5,7 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { LoginComponent } from './login.component';
 import { AuthService } from '../../../core/services/auth.service';
 
-@Component({ standalone: true, changeDetection: ChangeDetectionStrategy.Eager,
+@Component({ standalone: true, changeDetection: ChangeDetectionStrategy.OnPush,
  template: '' })
 class HomeStubComponent {}
 

--- a/JPPhotoManagerWeb/frontend/src/app/features/auth/login/login.component.html
+++ b/JPPhotoManagerWeb/frontend/src/app/features/auth/login/login.component.html
@@ -13,8 +13,8 @@
           <mat-label>Password</mat-label>
           <input matInput type="password" formControlName="password" autocomplete="current-password" />
         </mat-form-field>
-        @if (errorMessage) {
-          <p class="error-message">{{ errorMessage }}</p>
+        @if (errorMessage()) {
+          <p class="error-message">{{ errorMessage() }}</p>
         }
         <button mat-raised-button color="primary" type="submit" class="full-width">Sign In</button>
       </form>

--- a/JPPhotoManagerWeb/frontend/src/app/features/auth/login/login.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/auth/login/login.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ChangeDetectionStrategy, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
 import { MatCardModule } from '@angular/material/card';
@@ -12,7 +12,7 @@ import { AuthService } from '../../../core/services/auth.service';
   standalone: true,
   imports: [ReactiveFormsModule, MatCardModule, MatFormFieldModule, MatInputModule, MatButtonModule],
   templateUrl: './login.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './login.component.scss'
 })
 export class LoginComponent {
@@ -20,7 +20,7 @@ export class LoginComponent {
     username: ['', Validators.required],
     password: ['', Validators.required]
   });
-  errorMessage: string | null = null;
+  readonly errorMessage = signal<string | null>(null);
 
   constructor(
     private fb: FormBuilder,
@@ -37,7 +37,7 @@ export class LoginComponent {
         const returnUrl = this.route.snapshot.queryParamMap.get('returnUrl');
         this.router.navigateByUrl(this.sanitizeReturnUrl(returnUrl));
       },
-      error: () => { this.errorMessage = 'Invalid username or password.'; }
+      error: () => { this.errorMessage.set('Invalid username or password.'); }
     });
   }
 

--- a/JPPhotoManagerWeb/frontend/src/app/features/convert/convert.component.cy.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/convert/convert.component.cy.ts
@@ -48,7 +48,7 @@ describe('ConvertComponent', () => {
 
   it('should start on the configure step', () => {
     mountComponent().then(({ fixture }) => {
-      expect(fixture.componentInstance.step).to.equal('configure');
+      expect(fixture.componentInstance.step()).to.equal('configure');
     });
   });
 
@@ -61,17 +61,17 @@ describe('ConvertComponent', () => {
   it('should populate definitions from loaded configuration', () => {
     mountComponent().then(({ fixture }) => {
       fixture.detectChanges();
-      expect(fixture.componentInstance.definitions).to.deep.equal(mockDefinitions);
+      expect(fixture.componentInstance.definitions()).to.deep.equal(mockDefinitions);
     });
   });
 
   it('should add a new empty definition', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      const initialLength = component.definitions.length;
+      const initialLength = component.definitions().length;
       component.addDefinition();
-      expect(component.definitions).to.have.length(initialLength + 1);
-      expect(component.definitions[initialLength].sourceDirectory).to.equal('');
+      expect(component.definitions()).to.have.length(initialLength + 1);
+      expect(component.definitions()[initialLength].sourceDirectory).to.equal('');
     });
   });
 
@@ -95,9 +95,9 @@ describe('ConvertComponent', () => {
   it('should create a new array reference when a definition is added', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      const originalRef = component.definitions;
+      const originalRef = component.definitions();
       component.addDefinition();
-      expect(component.definitions).to.not.equal(originalRef);
+      expect(component.definitions()).to.not.equal(originalRef);
     });
   });
 
@@ -105,7 +105,7 @@ describe('ConvertComponent', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
       component.removeDefinition(0);
-      expect(component.definitions).to.have.length(0);
+      expect(component.definitions()).to.have.length(0);
     });
   });
 
@@ -121,77 +121,77 @@ describe('ConvertComponent', () => {
   it('should create a new array reference when a definition is removed', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      const originalRef = component.definitions;
+      const originalRef = component.definitions();
       component.removeDefinition(0);
-      expect(component.definitions).to.not.equal(originalRef);
+      expect(component.definitions()).to.not.equal(originalRef);
     });
   });
 
   it('should move a definition up', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.definitions = [
+      component.definitions.set([
         { ...mockDefinitions[0], order: 0 },
         { sourceDirectory: '/b', destinationDirectory: '/c', includeSubFolders: false, deleteAssetsNotInSource: false, order: 1 },
-      ];
+      ]);
       component.moveUp(1);
-      expect(component.definitions[0].sourceDirectory).to.equal('/b');
+      expect(component.definitions()[0].sourceDirectory).to.equal('/b');
     });
   });
 
   it('should create a new array reference when a definition is moved up', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.definitions = [
+      component.definitions.set([
         { ...mockDefinitions[0], order: 0 },
         { sourceDirectory: '/b', destinationDirectory: '/c', includeSubFolders: false, deleteAssetsNotInSource: false, order: 1 },
-      ];
-      const originalRef = component.definitions;
+      ]);
+      const originalRef = component.definitions();
       component.moveUp(1);
-      expect(component.definitions).to.not.equal(originalRef);
+      expect(component.definitions()).to.not.equal(originalRef);
     });
   });
 
   it('should not move a definition up when already at the top', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      const first = component.definitions[0];
+      const first = component.definitions()[0];
       component.moveUp(0);
-      expect(component.definitions[0]).to.equal(first);
+      expect(component.definitions()[0]).to.equal(first);
     });
   });
 
   it('should move a definition down', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.definitions = [
+      component.definitions.set([
         { ...mockDefinitions[0], order: 0 },
         { sourceDirectory: '/b', destinationDirectory: '/c', includeSubFolders: false, deleteAssetsNotInSource: false, order: 1 },
-      ];
+      ]);
       component.moveDown(0);
-      expect(component.definitions[0].sourceDirectory).to.equal('/b');
+      expect(component.definitions()[0].sourceDirectory).to.equal('/b');
     });
   });
 
   it('should create a new array reference when a definition is moved down', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.definitions = [
+      component.definitions.set([
         { ...mockDefinitions[0], order: 0 },
         { sourceDirectory: '/b', destinationDirectory: '/c', includeSubFolders: false, deleteAssetsNotInSource: false, order: 1 },
-      ];
-      const originalRef = component.definitions;
+      ]);
+      const originalRef = component.definitions();
       component.moveDown(0);
-      expect(component.definitions).to.not.equal(originalRef);
+      expect(component.definitions()).to.not.equal(originalRef);
     });
   });
 
   it('should not move a definition down when already at the bottom', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      const last = component.definitions[component.definitions.length - 1];
-      component.moveDown(component.definitions.length - 1);
-      expect(component.definitions[component.definitions.length - 1]).to.equal(last);
+      const last = component.definitions()[component.definitions().length - 1];
+      component.moveDown(component.definitions().length - 1);
+      expect(component.definitions()[component.definitions().length - 1]).to.equal(last);
     });
   });
 
@@ -203,7 +203,7 @@ describe('ConvertComponent', () => {
     mountComponent({ run, setConfiguration }).then(({ fixture }) => {
       fixture.componentInstance.saveAndRun();
       fixture.detectChanges();
-      expect(fixture.componentInstance.step).to.equal('running');
+      expect(fixture.componentInstance.step()).to.equal('running');
     });
   });
 
@@ -221,8 +221,8 @@ describe('ConvertComponent', () => {
         mockSource.emitRaw('results', JSON.stringify(mockResults));
         fixture.detectChanges();
 
-        expect(fixture.componentInstance.step).to.equal('results');
-        expect(fixture.componentInstance.results).to.deep.equal(mockResults);
+        expect(fixture.componentInstance.step()).to.equal('results');
+        expect(fixture.componentInstance.results()).to.deep.equal(mockResults);
       });
   });
 
@@ -238,16 +238,16 @@ describe('ConvertComponent', () => {
         mockSource.emitRaw('status', 'Converting file 2');
         fixture.detectChanges();
 
-        expect(fixture.componentInstance.statusMessages).to.deep.equal(['Converting file 1', 'Converting file 2']);
+        expect(fixture.componentInstance.statusMessages()).to.deep.equal(['Converting file 1', 'Converting file 2']);
       });
   });
 
   it('should return to configure step when backToConfigure is called', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.step = 'results';
+      component.step.set('results');
       component.backToConfigure();
-      expect(component.step).to.equal('configure');
+      expect(component.step()).to.equal('configure');
     });
   });
 

--- a/JPPhotoManagerWeb/frontend/src/app/features/convert/convert.component.html
+++ b/JPPhotoManagerWeb/frontend/src/app/features/convert/convert.component.html
@@ -1,10 +1,10 @@
 <div class="convert-container p-16">
   <h2>Convert Assets (PNG → JPEG)</h2>
 
-  @if (step === 'configure') {
+  @if (step() === 'configure') {
     <mat-card>
       <mat-card-content>
-        <table mat-table [dataSource]="definitions" class="full-width">
+        <table mat-table [dataSource]="definitions()" class="full-width">
           <ng-container matColumnDef="sourceDirectory">
             <th mat-header-cell *matHeaderCellDef>Source Directory</th>
             <td mat-cell *matCellDef="let def">
@@ -34,7 +34,7 @@
             <th mat-header-cell *matHeaderCellDef>Actions</th>
             <td mat-cell *matCellDef="let def; let i = index">
               <button mat-icon-button (click)="moveUp(i)" [disabled]="i === 0"><mat-icon>arrow_upward</mat-icon></button>
-              <button mat-icon-button (click)="moveDown(i)" [disabled]="i === definitions.length - 1"><mat-icon>arrow_downward</mat-icon></button>
+              <button mat-icon-button (click)="moveDown(i)" [disabled]="i === definitions().length - 1"><mat-icon>arrow_downward</mat-icon></button>
               <button mat-icon-button color="warn" (click)="removeDefinition(i)"><mat-icon>delete</mat-icon></button>
             </td>
           </ng-container>
@@ -46,20 +46,20 @@
 
       <mat-card-actions>
         <button mat-button (click)="addDefinition()"><mat-icon>add</mat-icon> Add</button>
-        <button mat-raised-button color="primary" (click)="saveAndRun()" [disabled]="definitions.length === 0 || !authService.isAdmin()">
+        <button mat-raised-button color="primary" (click)="saveAndRun()" [disabled]="definitions().length === 0 || !authService.isAdmin()">
           <mat-icon>play_arrow</mat-icon> Save & Run
         </button>
       </mat-card-actions>
     </mat-card>
   }
 
-  @if (step === 'running') {
+  @if (step() === 'running') {
     <mat-card>
       <mat-card-content>
         <mat-progress-bar mode="indeterminate" />
         <p>Converting in progress...</p>
         <mat-list>
-          @for (msg of statusMessages; track $index) {
+          @for (msg of statusMessages(); track $index) {
             <mat-list-item>{{ msg }}</mat-list-item>
           }
         </mat-list>
@@ -67,11 +67,11 @@
     </mat-card>
   }
 
-  @if (step === 'results') {
+  @if (step() === 'results') {
     <mat-card>
       <mat-card-header><mat-card-title>Results</mat-card-title></mat-card-header>
       <mat-card-content>
-        @for (result of results; track $index) {
+        @for (result of results(); track $index) {
           <div class="result-item" [class.result-error]="!result.success">
             <strong>{{ result.sourceDirectory }} → {{ result.destinationDirectory }}</strong>
             <span>Converted: {{ result.convertedCount }}, Failed: {{ result.failedCount }}</span>

--- a/JPPhotoManagerWeb/frontend/src/app/features/convert/convert.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/convert/convert.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnDestroy, OnInit, ChangeDetectionStrategy, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatTableModule } from '@angular/material/table';
 import { MatButtonModule } from '@angular/material/button';
@@ -30,16 +30,16 @@ type ProcessStep = 'configure' | 'running' | 'results';
     MatListModule
   ],
   templateUrl: './convert.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './convert.component.scss'
 })
 export class ConvertComponent implements OnInit, OnDestroy {
 
-  step: ProcessStep = 'configure';
-  definitions: ConvertAssetsDirectoriesDefinition[] = [];
-  statusMessages: string[] = [];
-  results: ConvertAssetsResult[] = [];
-  running = false;
+  readonly step = signal<ProcessStep>('configure');
+  readonly definitions = signal<ConvertAssetsDirectoriesDefinition[]>([]);
+  readonly statusMessages = signal<string[]>([]);
+  readonly results = signal<ConvertAssetsResult[]>([]);
+  readonly running = signal(false);
 
   private eventSource?: EventSource;
 
@@ -53,7 +53,7 @@ export class ConvertComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.convertService.getConfiguration().subscribe({
-      next: defs => this.definitions = defs,
+      next: defs => this.definitions.set(defs),
       error: () => this.snackBar.open('Failed to load configuration', 'Dismiss', { duration: 3000 })
     });
   }
@@ -63,70 +63,73 @@ export class ConvertComponent implements OnInit, OnDestroy {
   }
 
   addDefinition(): void {
-    this.definitions = [...this.definitions, {
+    this.definitions.update(defs => [...defs, {
       sourceDirectory: '',
       destinationDirectory: '',
       includeSubFolders: false,
       deleteAssetsNotInSource: false,
-      order: this.definitions.length
-    }];
+      order: defs.length
+    }]);
   }
 
   removeDefinition(index: number): void {
-    this.definitions = this.definitions.filter((_, i) => i !== index);
+    this.definitions.update(defs => defs.filter((_, i) => i !== index));
   }
 
   moveUp(index: number): void {
     if (index > 0) {
-      const updated = [...this.definitions];
-      [updated[index - 1], updated[index]] = [updated[index], updated[index - 1]];
-      this.definitions = updated;
+      this.definitions.update(defs => {
+        const updated = [...defs];
+        [updated[index - 1], updated[index]] = [updated[index], updated[index - 1]];
+        return updated;
+      });
     }
   }
 
   moveDown(index: number): void {
-    if (index < this.definitions.length - 1) {
-      const updated = [...this.definitions];
+    this.definitions.update(defs => {
+      if (index >= defs.length - 1) return defs;
+      const updated = [...defs];
       [updated[index], updated[index + 1]] = [updated[index + 1], updated[index]];
-      this.definitions = updated;
-    }
+      return updated;
+    });
   }
 
   saveAndRun(): void {
-    this.convertService.setConfiguration(this.definitions).subscribe({
+    this.convertService.setConfiguration(this.definitions()).subscribe({
       next: () => this.runConvert(),
       error: () => this.snackBar.open('Failed to save configuration', 'Dismiss', { duration: 3000 })
     });
   }
 
   private runConvert(): void {
-    this.step = 'running';
-    this.running = true;
-    this.statusMessages = [];
-    this.results = [];
+    this.step.set('running');
+    this.running.set(true);
+    this.statusMessages.set([]);
+    this.results.set([]);
 
     const eventSource = this.convertService.run();
     this.eventSource = eventSource;
 
     eventSource.addEventListener('status', (event: MessageEvent) => {
-      this.statusMessages.push(event.data);
+      this.statusMessages.update(msgs => [...msgs, event.data]);
     });
 
     eventSource.addEventListener('results', (event: MessageEvent) => {
-      this.results = JSON.parse(event.data as string) as ConvertAssetsResult[];
-      this.step = 'results';
-      this.running = false;
+      this.results.set(JSON.parse(event.data as string) as ConvertAssetsResult[]);
+      this.step.set('results');
+      this.running.set(false);
       eventSource.close();
     });
 
     eventSource.addEventListener('error', () => {
-      this.running = false;
-      this.step = 'results';
+      this.running.set(false);
+      this.step.set('results');
       eventSource.close();
     });
   }
 
   backToConfigure(): void {
-    this.step = 'configure';
+    this.step.set('configure');
   }
 }

--- a/JPPhotoManagerWeb/frontend/src/app/features/duplicates/duplicates.component.cy.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/duplicates/duplicates.component.cy.ts
@@ -58,21 +58,21 @@ describe('DuplicatesComponent', () => {
   it('should display the correct number of duplicate groups', () => {
     mountComponent().then(({ fixture }) => {
       fixture.detectChanges();
-      expect(fixture.componentInstance.groups).to.have.length(2);
+      expect(fixture.componentInstance.groups()).to.have.length(2);
     });
   });
 
   it('should calculate totalDuplicates correctly', () => {
     mountComponent().then(({ fixture }) => {
       fixture.detectChanges();
-      expect(fixture.componentInstance.totalDuplicates).to.equal(3);
+      expect(fixture.componentInstance.totalDuplicates()).to.equal(3);
     });
   });
 
   it('should default keepIndex to 0 for each group', () => {
     mountComponent().then(({ fixture }) => {
       fixture.detectChanges();
-      fixture.componentInstance.groups.forEach(group => {
+      fixture.componentInstance.groups().forEach(group => {
         expect(group.keepIndex).to.equal(0);
       });
     });
@@ -82,7 +82,7 @@ describe('DuplicatesComponent', () => {
     mountComponent().then(({ fixture }) => {
       fixture.detectChanges();
       const component = fixture.componentInstance;
-      const group = component.groups[0];
+      const group = component.groups()[0];
       component.markAsKeep(group, 1);
       expect(group.keepIndex).to.equal(1);
     });
@@ -94,7 +94,7 @@ describe('DuplicatesComponent', () => {
     mountComponent({ deleteAssets }).then(({ fixture }) => {
       fixture.detectChanges();
       const component = fixture.componentInstance;
-      const group = component.groups[0];
+      const group = component.groups()[0];
       component.deleteGroup(group);
       cy.wrap(deleteAssets).should('have.been.calledWith', [2], true);
     });
@@ -104,9 +104,9 @@ describe('DuplicatesComponent', () => {
     mountComponent().then(({ fixture }) => {
       fixture.detectChanges();
       const component = fixture.componentInstance;
-      const initialLength = component.groups.length;
-      component.deleteGroup(component.groups[0]);
-      expect(component.groups).to.have.length(initialLength - 1);
+      const initialLength = component.groups().length;
+      component.deleteGroup(component.groups()[0]);
+      expect(component.groups()).to.have.length(initialLength - 1);
     });
   });
 
@@ -116,7 +116,7 @@ describe('DuplicatesComponent', () => {
     mountComponent({ deleteAssets }).then(({ fixture }) => {
       fixture.detectChanges();
       const component = fixture.componentInstance;
-      const group = component.groups[1];
+      const group = component.groups()[1];
       component.markAsKeep(group, 1);
       component.deleteGroup(group);
       cy.wrap(deleteAssets).should('have.been.calledWith', [3, 5], true);

--- a/JPPhotoManagerWeb/frontend/src/app/features/duplicates/duplicates.component.html
+++ b/JPPhotoManagerWeb/frontend/src/app/features/duplicates/duplicates.component.html
@@ -1,8 +1,8 @@
 <div class="duplicates-container p-16">
   <div class="flex-row" style="align-items: center; gap: 16px; margin-bottom: 16px;">
     <h2 style="margin: 0;">Duplicate Images</h2>
-    @if (!loading) {
-      <mat-chip>{{ groups.length }} groups, {{ totalDuplicates }} duplicates</mat-chip>
+    @if (!loading()) {
+      <mat-chip>{{ groups().length }} groups, {{ totalDuplicates() }} duplicates</mat-chip>
     }
     <span style="flex: 1"></span>
     <button mat-button (click)="loadDuplicates()">
@@ -10,18 +10,18 @@
     </button>
   </div>
 
-  @if (loading) {
+  @if (loading()) {
     <mat-progress-bar mode="indeterminate" />
   }
 
-  @if (!loading && groups.length === 0) {
+  @if (!loading() && groups().length === 0) {
     <div class="empty-state">
       <mat-icon style="font-size: 64px; width: 64px; height: 64px; color: var(--accent-color);">check_circle</mat-icon>
       <p>No duplicate images found.</p>
     </div>
   }
 
-  @for (group of groups; track $index) {
+  @for (group of groups(); track $index) {
     <mat-card class="group-card">
       <mat-card-header>
         <mat-card-title>Group {{ $index + 1 }} — {{ group.assets.length }} files</mat-card-title>

--- a/JPPhotoManagerWeb/frontend/src/app/features/duplicates/duplicates.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/duplicates/duplicates.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
@@ -26,14 +26,14 @@ import { FileSizePipe } from '../../shared/pipes/file-size.pipe';
     FileSizePipe
   ],
   templateUrl: './duplicates.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './duplicates.component.scss'
 })
 export class DuplicatesComponent implements OnInit {
 
-  groups: DuplicateGroup[] = [];
-  loading = false;
-  totalDuplicates = 0;
+  readonly groups = signal<DuplicateGroup[]>([]);
+  readonly loading = signal(false);
+  readonly totalDuplicates = signal(0);
 
   constructor(
     private assetService: AssetService,
@@ -45,15 +45,15 @@ export class DuplicatesComponent implements OnInit {
   }
 
   loadDuplicates(): void {
-    this.loading = true;
+    this.loading.set(true);
     this.assetService.getDuplicatedAssets().subscribe({
       next: (duplicateGroups: Asset[][]) => {
-        this.groups = duplicateGroups.map(assets => ({ assets, keepIndex: 0 }));
-        this.totalDuplicates = duplicateGroups.reduce((sum, g) => sum + g.length - 1, 0);
-        this.loading = false;
+        this.groups.set(duplicateGroups.map(assets => ({ assets, keepIndex: 0 })));
+        this.totalDuplicates.set(duplicateGroups.reduce((sum, g) => sum + g.length - 1, 0));
+        this.loading.set(false);
       },
       error: () => {
-        this.loading = false;
+        this.loading.set(false);
         this.snackBar.open('Failed to load duplicates', 'Dismiss', { duration: 3000 });
       }
     });
@@ -70,7 +70,7 @@ export class DuplicatesComponent implements OnInit {
 
     this.assetService.deleteAssets(toDelete, true).subscribe({
       next: () => {
-        this.groups = this.groups.filter(g => g !== group);
+        this.groups.update(list => list.filter(g => g !== group));
         this.snackBar.open(`Deleted ${toDelete.length} duplicate(s)`, undefined, { duration: 2000 });
       },
       error: () => this.snackBar.open('Failed to delete', 'Dismiss', { duration: 3000 })

--- a/JPPhotoManagerWeb/frontend/src/app/features/folder-nav/folder-nav.component.html
+++ b/JPPhotoManagerWeb/frontend/src/app/features/folder-nav/folder-nav.component.html
@@ -1,4 +1,4 @@
-@if (loading) {
+@if (loading()) {
   <div class="loading-spinner">
     <mat-spinner diameter="32" />
   </div>

--- a/JPPhotoManagerWeb/frontend/src/app/features/folder-nav/folder-nav.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/folder-nav/folder-nav.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Output, EventEmitter, ChangeDetectionStrategy } from "@angular/core";
+import { Component, OnInit, Output, EventEmitter, ChangeDetectionStrategy, signal } from "@angular/core";
 import {
   MatTreeModule,
   MatTreeFlatDataSource,
@@ -21,14 +21,14 @@ import { Folder, FlatFolder } from "../../core/models/folder.model";
     MatProgressSpinnerModule,
   ],
   templateUrl: "./folder-nav.component.html",
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: "./folder-nav.component.scss",
 })
 export class FolderNavComponent implements OnInit {
   @Output() folderSelected = new EventEmitter<string>();
 
   selectedPath: string = "";
-  loading = false;
+  readonly loading = signal(false);
 
   private transformer = (node: Folder, level: number): FlatFolder => ({
     expandable: !!node.children && node.children.length > 0,
@@ -54,14 +54,14 @@ export class FolderNavComponent implements OnInit {
   constructor(private folderService: FolderService) {}
 
   ngOnInit(): void {
-    this.loading = true;
+    this.loading.set(true);
     this.folderService.getFolders().subscribe({
       next: (folders) => {
         this.dataSource.data = this.buildTree(folders);
-        this.loading = false;
+        this.loading.set(false);
       },
       error: () => {
-        this.loading = false;
+        this.loading.set(false);
       },
     });
   }

--- a/JPPhotoManagerWeb/frontend/src/app/features/gallery/add-to-album-dialog/add-to-album-dialog.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/gallery/add-to-album-dialog/add-to-album-dialog.component.ts
@@ -55,7 +55,7 @@ import { AddToAlbumDialogData, AddToAlbumDialogResult } from '../../../core/mode
       </button>
     </mat-dialog-actions>
   `,
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [`.album-radio-group { display: flex; flex-direction: column; gap: 8px; }`]
 })
 export class AddToAlbumDialogComponent {

--- a/JPPhotoManagerWeb/frontend/src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.html
+++ b/JPPhotoManagerWeb/frontend/src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.html
@@ -16,13 +16,13 @@
     Tokens: <code>&#123;date:yyyy-MM-dd&#125;</code> · <code>&#123;index:03d&#125;</code> · <code>&#123;original&#125;</code> · <code>&#123;ext&#125;</code>
   </p>
 
-  @if (previewError) {
-    <p class="preview-error">{{ previewError }}</p>
+  @if (previewError()) {
+    <p class="preview-error">{{ previewError() }}</p>
   }
 
-  @if (previews.length > 0) {
+  @if (previews().length > 0) {
     <div class="preview-table-wrapper">
-      <table mat-table [dataSource]="previews" class="preview-table">
+      <table mat-table [dataSource]="previews()" class="preview-table">
         <ng-container matColumnDef="oldName">
           <th mat-header-cell *matHeaderCellDef>Old name</th>
           <td mat-cell *matCellDef="let row">{{ row.oldName }}</td>

--- a/JPPhotoManagerWeb/frontend/src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnDestroy, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Inject, OnDestroy, OnInit, ChangeDetectionStrategy, signal } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
@@ -27,13 +27,13 @@ import { BatchRenameDialogData } from '../../../core/models/dialog.model';
     MatTableModule,
   ],
   templateUrl: './batch-rename-dialog.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './batch-rename-dialog.component.scss',
 })
 export class BatchRenameDialogComponent implements OnInit, OnDestroy {
   pattern = '';
-  previews: RenamePreview[] = [];
-  previewError: string | null = null;
+  readonly previews = signal<RenamePreview[]>([]);
+  readonly previewError = signal<string | null>(null);
   isApplying = false;
   readonly displayedColumns = ['oldName', 'newName'];
 
@@ -52,8 +52,8 @@ export class BatchRenameDialogComponent implements OnInit, OnDestroy {
       distinctUntilChanged(),
       switchMap(p => {
         if (!p) {
-          this.previews = [];
-          this.previewError = null;
+          this.previews.set([]);
+          this.previewError.set(null);
           return of(null);
         }
         return this.assetService.renameAssets(this.data.assetIds, p, false);
@@ -62,13 +62,13 @@ export class BatchRenameDialogComponent implements OnInit, OnDestroy {
     ).subscribe({
       next: result => {
         if (result) {
-          this.previews = result.previews;
-          this.previewError = null;
+          this.previews.set(result.previews);
+          this.previewError.set(null);
         }
       },
       error: () => {
-        this.previewError = 'Invalid pattern or name collision.';
-        this.previews = [];
+        this.previewError.set('Invalid pattern or name collision.');
+        this.previews.set([]);
       },
     });
   }
@@ -79,12 +79,12 @@ export class BatchRenameDialogComponent implements OnInit, OnDestroy {
   }
 
   onPatternChange(value: string): void {
-    this.previewError = null;
+    this.previewError.set(null);
     this.patternChange$.next(value);
   }
 
   get canApply(): boolean {
-    return !!this.pattern && !this.previewError && !this.isApplying && this.previews.length > 0;
+    return !!this.pattern && !this.previewError() && !this.isApplying && this.previews().length > 0;
   }
 
   applyRename(): void {

--- a/JPPhotoManagerWeb/frontend/src/app/features/gallery/bulk-tag-dialog/bulk-tag-dialog.component.html
+++ b/JPPhotoManagerWeb/frontend/src/app/features/gallery/bulk-tag-dialog/bulk-tag-dialog.component.html
@@ -21,7 +21,7 @@
     />
   </mat-chip-grid>
   <mat-autocomplete #addAuto="matAutocomplete" (optionSelected)="addTagToAddFromAutocomplete($event)">
-    @for (suggestion of addSuggestions; track suggestion) {
+    @for (suggestion of addSuggestions(); track suggestion) {
       <mat-option [value]="suggestion">{{ suggestion }}</mat-option>
     }
   </mat-autocomplete>
@@ -46,18 +46,18 @@
     />
   </mat-chip-grid>
   <mat-autocomplete #removeAuto="matAutocomplete" (optionSelected)="addTagToRemoveFromAutocomplete($event)">
-    @for (suggestion of removeSuggestions; track suggestion) {
+    @for (suggestion of removeSuggestions(); track suggestion) {
       <mat-option [value]="suggestion">{{ suggestion }}</mat-option>
     }
   </mat-autocomplete>
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">
-  @if (isSaving) {
+  @if (isSaving()) {
     <mat-spinner diameter="24" style="margin-right: 12px;"></mat-spinner>
   }
-  <button mat-button (click)="cancel()" [disabled]="isSaving">Cancel</button>
-  <button mat-flat-button color="primary" (click)="confirm()" [disabled]="isSaving">
+  <button mat-button (click)="cancel()" [disabled]="isSaving()">Cancel</button>
+  <button mat-flat-button color="primary" (click)="confirm()" [disabled]="isSaving()">
     Apply
   </button>
 </mat-dialog-actions>

--- a/JPPhotoManagerWeb/frontend/src/app/features/gallery/bulk-tag-dialog/bulk-tag-dialog.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/gallery/bulk-tag-dialog/bulk-tag-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnDestroy, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Inject, OnDestroy, OnInit, ChangeDetectionStrategy, signal } from '@angular/core';
 import { ReactiveFormsModule, FormControl } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -28,18 +28,18 @@ import { BulkTagDialogData } from '../../../core/models/dialog.model';
     MatDialogModule,
     MatProgressSpinnerModule,
   ],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './bulk-tag-dialog.component.html',
 })
 export class BulkTagDialogComponent implements OnInit, OnDestroy {
   tagsToAdd: string[] = [];
   tagsToRemove: string[] = [];
-  addSuggestions: string[] = [];
-  removeSuggestions: string[] = [];
+  readonly addSuggestions = signal<string[]>([]);
+  readonly removeSuggestions = signal<string[]>([]);
   addInputControl = new FormControl<string>('', { nonNullable: true });
   removeInputControl = new FormControl<string>('', { nonNullable: true });
   readonly separatorKeysCodes = [ENTER, COMMA] as const;
-  isSaving = false;
+  readonly isSaving = signal(false);
 
   private readonly destroy$ = new Subject<void>();
 
@@ -57,10 +57,10 @@ export class BulkTagDialogComponent implements OnInit, OnDestroy {
     ).subscribe(q => {
       if (q && q.length >= 1) {
         this.tagService.searchTags(q).subscribe(tags => {
-          this.addSuggestions = tags.filter(t => !this.tagsToAdd.includes(t));
+          this.addSuggestions.set(tags.filter(t => !this.tagsToAdd.includes(t)));
         });
       } else {
-        this.addSuggestions = [];
+        this.addSuggestions.set([]);
       }
     });
 
@@ -71,10 +71,10 @@ export class BulkTagDialogComponent implements OnInit, OnDestroy {
     ).subscribe(q => {
       if (q && q.length >= 1) {
         this.tagService.searchTags(q).subscribe(tags => {
-          this.removeSuggestions = tags.filter(t => !this.tagsToRemove.includes(t));
+          this.removeSuggestions.set(tags.filter(t => !this.tagsToRemove.includes(t)));
         });
       } else {
-        this.removeSuggestions = [];
+        this.removeSuggestions.set([]);
       }
     });
   }
@@ -95,7 +95,7 @@ export class BulkTagDialogComponent implements OnInit, OnDestroy {
   addTagToAddFromAutocomplete(event: MatAutocompleteSelectedEvent): void {
     const name = event.option.viewValue.toLowerCase();
     this.addInputControl.setValue('', { emitEvent: false });
-    this.addSuggestions = [];
+    this.addSuggestions.set([]);
     if (!name || this.tagsToAdd.includes(name)) return;
     this.tagsToAdd = [...this.tagsToAdd, name];
   }
@@ -115,7 +115,7 @@ export class BulkTagDialogComponent implements OnInit, OnDestroy {
   addTagToRemoveFromAutocomplete(event: MatAutocompleteSelectedEvent): void {
     const name = event.option.viewValue.toLowerCase();
     this.removeInputControl.setValue('', { emitEvent: false });
-    this.removeSuggestions = [];
+    this.removeSuggestions.set([]);
     if (!name || this.tagsToRemove.includes(name)) return;
     this.tagsToRemove = [...this.tagsToRemove, name];
   }
@@ -129,14 +129,14 @@ export class BulkTagDialogComponent implements OnInit, OnDestroy {
       this.dialogRef.close(false);
       return;
     }
-    this.isSaving = true;
+    this.isSaving.set(true);
     const ids = this.data.assetIds;
     const addCalls = this.tagsToAdd.map(tag => this.tagService.bulkAddTag(ids, tag));
     const removeCalls = this.tagsToRemove.map(tag => this.tagService.bulkRemoveTag(ids, tag));
     forkJoin([...addCalls, ...removeCalls].length > 0 ? [...addCalls, ...removeCalls] : [of(undefined)]).subscribe({
       next: () => this.dialogRef.close(true),
       error: () => {
-        this.isSaving = false;
+        this.isSaving.set(false);
       },
     });
   }

--- a/JPPhotoManagerWeb/frontend/src/app/features/gallery/drop-zone/drop-zone.component.cy.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/gallery/drop-zone/drop-zone.component.cy.ts
@@ -42,25 +42,20 @@ describe('DropZoneComponent', () => {
     cy.get('.upload-queue').should('not.exist');
   });
 
+  // Dispatched as real DOM events (not direct component.onDragOver()/onDragLeave() calls) so
+  // they go through the @HostListener-wired Renderer2 dispatch the same way a real drag
+  // interaction would, rather than mutating isDragging outside Angular's notified paths.
   it('should show the drop overlay on a dragover event', () => {
-    mountDropZone().then(({ fixture }) => {
-      const component = fixture.componentInstance;
-      const mockEvent = { preventDefault: () => {} } as DragEvent;
-      component.onDragOver(mockEvent);
-      fixture.detectChanges();
-    });
+    mountDropZone();
+    cy.get('[data-cy-root]').trigger('dragover');
     cy.get('.drop-overlay').should('be.visible');
   });
 
   it('should hide the drop overlay on a dragleave event', () => {
-    mountDropZone().then(({ fixture }) => {
-      const component = fixture.componentInstance;
-      const mockEvent = { preventDefault: () => {} } as DragEvent;
-      component.onDragOver(mockEvent);
-      fixture.detectChanges();
-      component.onDragLeave();
-      fixture.detectChanges();
-    });
+    mountDropZone();
+    cy.get('[data-cy-root]').trigger('dragover');
+    cy.get('.drop-overlay').should('be.visible');
+    cy.get('[data-cy-root]').trigger('dragleave');
     cy.get('.drop-overlay').should('not.exist');
   });
 

--- a/JPPhotoManagerWeb/frontend/src/app/features/gallery/drop-zone/drop-zone.component.html
+++ b/JPPhotoManagerWeb/frontend/src/app/features/gallery/drop-zone/drop-zone.component.html
@@ -15,9 +15,9 @@
   (change)="onFileInputChange($event)"
 />
 
-@if (uploadQueue.length > 0) {
+@if (uploadQueue().length > 0) {
   <div class="upload-queue">
-    @for (item of uploadQueue; track item.file.name) {
+    @for (item of uploadQueue(); track item.file.name) {
       <div class="upload-item">
         <span class="upload-filename">{{ item.file.name }}</span>
         @if (item.status === 'uploading' || item.status === 'pending') {

--- a/JPPhotoManagerWeb/frontend/src/app/features/gallery/drop-zone/drop-zone.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/gallery/drop-zone/drop-zone.component.ts
@@ -7,7 +7,8 @@ import {
   OnDestroy,
   Output,
   ViewChild,
-  ChangeDetectionStrategy
+  ChangeDetectionStrategy,
+  signal
 } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -24,7 +25,7 @@ const ACCEPTED_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'gif', 'bmp', 'tiff',
   standalone: true,
   imports: [MatButtonModule, MatIconModule, MatProgressBarModule],
   templateUrl: './drop-zone.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './drop-zone.component.scss',
 })
 export class DropZoneComponent implements OnDestroy {
@@ -34,7 +35,7 @@ export class DropZoneComponent implements OnDestroy {
   @ViewChild('fileInput') private fileInput!: ElementRef<HTMLInputElement>;
 
   isDragging = false;
-  uploadQueue: UploadItem[] = [];
+  readonly uploadQueue = signal<UploadItem[]>([]);
 
   constructor(private assetService: AssetService) {}
 
@@ -42,9 +43,18 @@ export class DropZoneComponent implements OnDestroy {
     // Close any still-open observe streams (files whose processing hadn't finished when the
     // component was destroyed, e.g. the user navigated away from the gallery mid-upload) so the
     // browser connection and the server-side KafkaProgressRegistry emitter entry aren't leaked.
-    for (const item of this.uploadQueue) {
+    for (const item of this.uploadQueue()) {
       item.eventSource?.close();
     }
+  }
+
+  // Upload items are mutated in place (item.status/item.progress) for the frequent
+  // per-chunk progress updates rather than rebuilt immutably every tick; this re-sets
+  // the signal to a fresh array reference (same item objects) purely so it notifies -
+  // a signal's default Object.is equality means .set()ing the same array reference
+  // back would silently be a no-op.
+  private touchQueue(): void {
+    this.uploadQueue.update(q => [...q]);
   }
 
   @HostListener('dragover', ['$event'])
@@ -80,16 +90,16 @@ export class DropZoneComponent implements OnDestroy {
         : '';
       return ACCEPTED_EXTENSIONS.has(ext);
     });
-    for (const file of accepted) {
-      this.uploadQueue.push({ file, progress: 0, status: 'pending' });
-    }
-    if (accepted.length > 0) {
-      this.processQueue();
-    }
+    if (accepted.length === 0) return;
+    this.uploadQueue.update(q => [
+      ...q,
+      ...accepted.map(file => ({ file, progress: 0, status: 'pending' as const })),
+    ]);
+    this.processQueue();
   }
 
   processQueue(): void {
-    const pending = this.uploadQueue.filter(item => item.status === 'pending');
+    const pending = this.uploadQueue().filter(item => item.status === 'pending');
     if (pending.length === 0) {
       // The multipart POST queue is drained, but files still being processed asynchronously
       // (kafka-async-upload) may not have reached a terminal state yet; checkAllComplete()
@@ -99,10 +109,12 @@ export class DropZoneComponent implements OnDestroy {
     }
     const item = pending[0];
     item.status = 'uploading';
+    this.touchQueue();
     this.assetService.uploadAsset(this.folderPath, item.file).subscribe({
       next: event => {
         if (event.type === HttpEventType.UploadProgress && event.total) {
           item.progress = Math.round((event.loaded / event.total) * 100);
+          this.touchQueue();
         } else if (event.type === HttpEventType.Response) {
           item.progress = 100;
           const body = event.body as UploadAssetResponse | null;
@@ -115,11 +127,13 @@ export class DropZoneComponent implements OnDestroy {
             // have no assetId to open.
             item.status = 'done';
           }
+          this.touchQueue();
           this.processQueue();
         }
       },
       error: () => {
         item.status = 'error';
+        this.touchQueue();
         this.processQueue();
       },
     });
@@ -131,12 +145,14 @@ export class DropZoneComponent implements OnDestroy {
 
     eventSource.addEventListener('done', () => {
       item.status = 'done';
+      this.touchQueue();
       eventSource.close();
       this.checkAllComplete();
     });
 
     eventSource.addEventListener('failed', () => {
       item.status = 'error';
+      this.touchQueue();
       eventSource.close();
       this.checkAllComplete();
     });
@@ -146,13 +162,14 @@ export class DropZoneComponent implements OnDestroy {
       // row is the durable source of truth and a subsequent gallery refresh reflects the true
       // state regardless, so don't leave the row stuck on "Processing..." forever.
       item.status = 'done';
+      this.touchQueue();
       eventSource.close();
       this.checkAllComplete();
     };
   }
 
   private checkAllComplete(): void {
-    const stillActive = this.uploadQueue.some(
+    const stillActive = this.uploadQueue().some(
       item => item.status === 'pending' || item.status === 'uploading' || item.status === 'processing'
     );
     if (!stillActive) {

--- a/JPPhotoManagerWeb/frontend/src/app/features/gallery/exif-panel/exif-panel.component.html
+++ b/JPPhotoManagerWeb/frontend/src/app/features/gallery/exif-panel/exif-panel.component.html
@@ -29,17 +29,17 @@
       />
     </mat-chip-grid>
     <mat-autocomplete #auto="matAutocomplete" (optionSelected)="addTagFromAutocomplete($event)">
-      @for (suggestion of tagSuggestions; track suggestion) {
+      @for (suggestion of tagSuggestions(); track suggestion) {
         <mat-option [value]="suggestion">{{ suggestion }}</mat-option>
       }
     </mat-autocomplete>
   </div>
 
-  @if (loading) {
+  @if (loading()) {
     <div class="exif-loading">
       <mat-spinner diameter="24"></mat-spinner>
     </div>
-  } @else if (exif) {
+  } @else if (exif(); as exif) {
     <div class="exif-grid">
       @if (exif.cameraMake || exif.cameraModel) {
         <div class="exif-row">
@@ -109,7 +109,7 @@
     <div class="exif-empty">No EXIF data available</div>
   }
 
-  @if (exif?.rawExif) {
+  @if (exif()?.rawExif) {
     <mat-expansion-panel class="exif-raw-panel">
       <mat-expansion-panel-header>
         <mat-panel-title>All EXIF data</mat-panel-title>

--- a/JPPhotoManagerWeb/frontend/src/app/features/gallery/exif-panel/exif-panel.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/gallery/exif-panel/exif-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, HostBinding, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, ChangeDetectionStrategy } from '@angular/core';
+import { ChangeDetectorRef, Component, EventEmitter, HostBinding, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, ChangeDetectionStrategy, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule, FormControl } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
@@ -34,7 +34,7 @@ import { ExifMetadata } from '../../../core/models/exif-metadata.model';
     MatInputModule,
   ],
   templateUrl: './exif-panel.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './exif-panel.component.scss'
 })
 export class ExifPanelComponent implements OnChanges, OnInit, OnDestroy {
@@ -47,15 +47,16 @@ export class ExifPanelComponent implements OnChanges, OnInit, OnDestroy {
     return this.visible ? 'flex' : 'none';
   }
 
-  exif: ExifMetadata | null = null;
-  loading = false;
+  readonly exif = signal<ExifMetadata | null>(null);
+  readonly loading = signal(false);
   filterText = '';
-  tagSuggestions: string[] = [];
+  readonly tagSuggestions = signal<string[]>([]);
   tagInputControl = new FormControl<string>('', { nonNullable: true });
   readonly separatorKeysCodes = [ENTER, COMMA] as const;
 
   private cache = new Map<number, ExifMetadata | null>();
   private destroy$ = new Subject<void>();
+  private readonly cdr = inject(ChangeDetectorRef);
 
   constructor(
     private assetService: AssetService,
@@ -70,37 +71,37 @@ export class ExifPanelComponent implements OnChanges, OnInit, OnDestroy {
     ).subscribe(q => {
       if (q && q.length >= 1) {
         this.tagService.searchTags(q).pipe(takeUntil(this.destroy$)).subscribe(tags => {
-          this.tagSuggestions = tags.filter(t => !(this.asset?.tags ?? []).includes(t));
+          this.tagSuggestions.set(tags.filter(t => !(this.asset?.tags ?? []).includes(t)));
         });
       } else {
-        this.tagSuggestions = [];
+        this.tagSuggestions.set([]);
       }
     });
   }
 
   ngOnChanges(changes: SimpleChanges): void {
     if ('asset' in changes) {
-      this.tagSuggestions = [];
+      this.tagSuggestions.set([]);
       this.tagInputControl.setValue('', { emitEvent: false });
     }
 
     if (this.visible && this.asset?.assetId != null && ('visible' in changes || 'asset' in changes)) {
       const assetId = this.asset.assetId;
       if (this.cache.has(assetId)) {
-        this.exif = this.cache.get(assetId) ?? null;
-        this.loading = false;
+        this.exif.set(this.cache.get(assetId) ?? null);
+        this.loading.set(false);
       } else {
-        this.loading = true;
-        this.exif = null;
+        this.loading.set(true);
+        this.exif.set(null);
         this.assetService.getExifMetadata(assetId).subscribe({
           next: (data) => {
             this.cache.set(assetId, data);
-            this.exif = data;
-            this.loading = false;
+            this.exif.set(data);
+            this.loading.set(false);
           },
           error: () => {
             this.cache.set(assetId, null);
-            this.loading = false;
+            this.loading.set(false);
           }
         });
       }
@@ -121,6 +122,7 @@ export class ExifPanelComponent implements OnChanges, OnInit, OnDestroy {
     this.tagService.addTag(this.asset.assetId, name).subscribe({
       error: () => {
         this.asset.tags = (this.asset.tags ?? []).filter(t => t !== name);
+        this.cdr.markForCheck();
       }
     });
   }
@@ -128,12 +130,13 @@ export class ExifPanelComponent implements OnChanges, OnInit, OnDestroy {
   addTagFromAutocomplete(event: MatAutocompleteSelectedEvent): void {
     const name = event.option.viewValue.toLowerCase();
     this.tagInputControl.setValue('', { emitEvent: false });
-    this.tagSuggestions = [];
+    this.tagSuggestions.set([]);
     if (!name || (this.asset.tags ?? []).includes(name)) return;
     this.asset.tags = [...(this.asset.tags ?? []), name];
     this.tagService.addTag(this.asset.assetId, name).subscribe({
       error: () => {
         this.asset.tags = (this.asset.tags ?? []).filter(t => t !== name);
+        this.cdr.markForCheck();
       }
     });
   }
@@ -144,12 +147,13 @@ export class ExifPanelComponent implements OnChanges, OnInit, OnDestroy {
     this.tagService.removeTag(this.asset.assetId, name).subscribe({
       error: () => {
         this.asset.tags = previousTags;
+        this.cdr.markForCheck();
       }
     });
   }
 
   filteredRawExif(): { key: string; value: string }[] {
-    return Object.entries(this.exif?.rawExif ?? {})
+    return Object.entries(this.exif()?.rawExif ?? {})
       .filter(([k]) => k.toLowerCase().includes(this.filterText.toLowerCase()))
       .map(([key, value]) => ({ key, value }));
   }

--- a/JPPhotoManagerWeb/frontend/src/app/features/gallery/folder-picker-dialog/folder-picker-dialog.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/gallery/folder-picker-dialog/folder-picker-dialog.component.ts
@@ -13,7 +13,7 @@ import { FolderPickerDialogData, FolderPickerDialogResult } from '../../../core/
     FolderNavComponent,
   ],
   templateUrl: './folder-picker-dialog.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './folder-picker-dialog.component.scss',
 })
 export class FolderPickerDialogComponent {

--- a/JPPhotoManagerWeb/frontend/src/app/features/gallery/gallery.component.cy.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/gallery/gallery.component.cy.ts
@@ -200,7 +200,7 @@ describe('GalleryComponent', () => {
   it('should toggle asset selection', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.assets = mockAssets;
+      component.assets.set(mockAssets);
       fixture.detectChanges();
 
       component.toggleSelection(mockAssets[0]);
@@ -214,10 +214,10 @@ describe('GalleryComponent', () => {
   it('should switch to viewer mode when openViewer is called', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.assets = mockAssets;
+      component.assets.set(mockAssets);
       component.openViewer(1);
       expect(component.viewMode).to.equal('viewer');
-      expect(component.currentViewerIndex).to.equal(1);
+      expect(component.currentViewerIndex()).to.equal(1);
     });
   });
 
@@ -233,40 +233,40 @@ describe('GalleryComponent', () => {
   it('should navigate to previous asset in viewer', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.assets = mockAssets;
+      component.assets.set(mockAssets);
       component.openViewer(1);
       component.viewerPrev();
-      expect(component.currentViewerIndex).to.equal(0);
+      expect(component.currentViewerIndex()).to.equal(0);
     });
   });
 
   it('should navigate to next asset in viewer', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.assets = mockAssets;
+      component.assets.set(mockAssets);
       component.openViewer(0);
       component.viewerNext();
-      expect(component.currentViewerIndex).to.equal(1);
+      expect(component.currentViewerIndex()).to.equal(1);
     });
   });
 
   it('should not navigate before first asset in viewer', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.assets = mockAssets;
+      component.assets.set(mockAssets);
       component.openViewer(0);
       component.viewerPrev();
-      expect(component.currentViewerIndex).to.equal(0);
+      expect(component.currentViewerIndex()).to.equal(0);
     });
   });
 
   it('should not navigate past last asset in viewer', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.assets = mockAssets;
+      component.assets.set(mockAssets);
       component.openViewer(1);
       component.viewerNext();
-      expect(component.currentViewerIndex).to.equal(1);
+      expect(component.currentViewerIndex()).to.equal(1);
     });
   });
 
@@ -274,16 +274,16 @@ describe('GalleryComponent', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
       component.zoomIn();
-      expect(component.viewerZoom).to.equal(1.25);
+      expect(component.viewerZoom()).to.equal(1.25);
     });
   });
 
   it('should decrease zoom within limit', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.viewerZoom = 1;
+      component.viewerZoom.set(1);
       component.zoomOut();
-      expect(component.viewerZoom).to.equal(0.75);
+      expect(component.viewerZoom()).to.equal(0.75);
     });
   });
 
@@ -293,9 +293,9 @@ describe('GalleryComponent', () => {
     mountGallery({ getAssets }).then(({ fixture }) => {
       const component = fixture.componentInstance;
       component.currentFolder = '/photos';
-      component.pageIndex = 3;
+      component.pageIndex.set(3);
       component.onSortChange();
-      expect(component.pageIndex).to.equal(0);
+      expect(component.pageIndex()).to.equal(0);
     });
   });
 
@@ -306,8 +306,8 @@ describe('GalleryComponent', () => {
     mountGallery({ deleteAssets, getAssets }).then(({ fixture }) => {
       const component = fixture.componentInstance;
       component.currentFolder = '/photos';
-      component.selectedAssets.add(1);
-      component.selectedAssets.add(2);
+      component.selectedAssets.update(s => new Set(s).add(1));
+      component.selectedAssets.update(s => new Set(s).add(2));
       component.deleteSelected(false);
       cy.wrap(deleteAssets).should('have.been.calledWith', [1, 2], false);
     });
@@ -361,9 +361,9 @@ describe('GalleryComponent', () => {
 
     mountGallery({ getAssets }).then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.assets = [...mockAssets];
+      component.assets.set([...mockAssets]);
       component.onFolderSelected('/new-folder');
-      expect(component.assets).to.deep.equal([]);
+      expect(component.assets()).to.deep.equal([]);
       return Promise.resolve().then(() => fixture.detectChanges());
     });
 
@@ -377,10 +377,10 @@ describe('GalleryComponent', () => {
     mountGallery({ getAssets }).then(({ fixture }) => {
       const component = fixture.componentInstance;
       component.currentFolder = '/photos';
-      component.assets = [...mockAssets];
+      component.assets.set([...mockAssets]);
       component.sortCriteria = 'FILE_SIZE';
       component.onSortChange();
-      expect(component.assets).to.deep.equal([]);
+      expect(component.assets()).to.deep.equal([]);
       return Promise.resolve().then(() => fixture.detectChanges());
     });
 
@@ -391,7 +391,7 @@ describe('GalleryComponent', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
       component.currentFolder = '/photos';
-      component.isLoading = true;
+      component.isLoading.set(true);
       fixture.detectChanges();
     });
 
@@ -401,8 +401,8 @@ describe('GalleryComponent', () => {
   it('should show the end-of-list indicator when allLoaded is true', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.assets = [...mockAssets];
-      component.allLoaded = true;
+      component.assets.set([...mockAssets]);
+      component.allLoaded.set(true);
       fixture.detectChanges();
     });
 
@@ -418,7 +418,7 @@ describe('GalleryComponent', () => {
 
     mountGallery({ downloadAssets }).then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.selectedAssets.add(1);
+      component.selectedAssets.update(s => new Set(s).add(1));
       component.downloadSelected();
       cy.wrap(downloadAssets).should('have.been.calledWith', [1]);
     });
@@ -429,7 +429,7 @@ describe('GalleryComponent', () => {
 
     mountGallery({ downloadAssets }).then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.selectedAssets.add(1);
+      component.selectedAssets.update(s => new Set(s).add(1));
       component.downloadSelected();
     });
 
@@ -442,7 +442,7 @@ describe('GalleryComponent', () => {
     mountGallery({ getAssets }).then(({ fixture }) => {
       const component = fixture.componentInstance;
       component.currentFolder = '/photos';
-      component.allLoaded = true;
+      component.allLoaded.set(true);
       component.loadNextPage();
     });
 
@@ -478,31 +478,31 @@ describe('GalleryComponent', () => {
   it('should increment the current viewer index when the slideshow advances', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.assets = [...mockAssets];
+      component.assets.set([...mockAssets]);
       component.startSlideshow(0);
       fixture.detectChanges();
-      expect(component.currentViewerIndex).to.equal(0);
+      expect(component.currentViewerIndex()).to.equal(0);
       component.advanceSlideshow();
-      expect(component.currentViewerIndex).to.equal(1);
+      expect(component.currentViewerIndex()).to.equal(1);
     });
   });
 
   it('should stop advancing when the slideshow is paused while playing', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.assets = [...mockAssets];
+      component.assets.set([...mockAssets]);
       component.startSlideshow(0);
       component.pauseSlideshow();
-      expect(component.slideshowPlaying).to.be.false;
+      expect(component.slideshowPlaying()).to.be.false;
       expect((component as unknown as { slideshowTimer: ReturnType<typeof setInterval> | null }).slideshowTimer).to.be.null;
-      expect(component.currentViewerIndex).to.equal(0);
+      expect(component.currentViewerIndex()).to.equal(0);
     });
   });
 
   it('should return to viewer mode when Escape is pressed during the slideshow', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.assets = [...mockAssets];
+      component.assets.set([...mockAssets]);
       component.startSlideshow(0);
       fixture.detectChanges();
       component.onKeyDown(new KeyboardEvent('keydown', { key: 'Escape' }));
@@ -513,36 +513,36 @@ describe('GalleryComponent', () => {
   it('should toggle play/pause when the space key is pressed during the slideshow', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.assets = [...mockAssets];
+      component.assets.set([...mockAssets]);
       component.startSlideshow(0);
-      expect(component.slideshowPlaying).to.be.true;
+      expect(component.slideshowPlaying()).to.be.true;
       component.onKeyDown(new KeyboardEvent('keydown', { key: ' ' }));
-      expect(component.slideshowPlaying).to.be.false;
+      expect(component.slideshowPlaying()).to.be.false;
       component.onKeyDown(new KeyboardEvent('keydown', { key: ' ' }));
-      expect(component.slideshowPlaying).to.be.true;
+      expect(component.slideshowPlaying()).to.be.true;
     });
   });
 
   it('should stop the slideshow and show a complete message at the last asset', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.assets = [...mockAssets];
+      component.assets.set([...mockAssets]);
       component.startSlideshow(1); // last index
       component.advanceSlideshow(); // at last asset — should stop
-      expect(component.slideshowPlaying).to.be.false;
-      expect(component.statusMessage).to.equal('Slideshow complete');
+      expect(component.slideshowPlaying()).to.be.false;
+      expect(component.statusMessage()).to.equal('Slideshow complete');
     });
   });
 
   it('should keep the same index when starting the slideshow from the viewer toolbar', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.assets = [...mockAssets];
+      component.assets.set([...mockAssets]);
       component.openViewer(1);
       expect(component.viewMode).to.equal('viewer');
-      component.startSlideshow(component.currentViewerIndex);
+      component.startSlideshow(component.currentViewerIndex());
       expect(component.viewMode).to.equal('slideshow');
-      expect(component.currentViewerIndex).to.equal(1);
+      expect(component.currentViewerIndex()).to.equal(1);
     });
   });
 
@@ -615,8 +615,8 @@ describe('GalleryComponent', () => {
   it('should show the toggle button with the sidenav in over mode on a mobile viewport', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.isMobile = true;
-      component.sidenavOpen = false;
+      component.isMobile.set(true);
+      component.sidenavOpen.set(false);
       fixture.detectChanges();
     });
 
@@ -659,14 +659,14 @@ describe('GalleryComponent', () => {
   it('should close the sidenav when a folder is selected on a mobile viewport', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.isMobile = true;
-      component.sidenavOpen = true;
+      component.isMobile.set(true);
+      component.sidenavOpen.set(true);
       fixture.detectChanges();
 
       component.onFolderSelected('/photos');
       fixture.detectChanges();
 
-      expect(component.sidenavOpen).to.be.false;
+      expect(component.sidenavOpen()).to.be.false;
       cy.get('mat-sidenav').should('not.have.class', 'mat-drawer-opened');
     });
   });
@@ -678,7 +678,7 @@ describe('GalleryComponent', () => {
 
     mountGallery({ rateAsset }).then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.assets = [...mockAssets];
+      component.assets.set([...mockAssets]);
       component.rateAsset(mockAssets[0], 4);
       cy.wrap(rateAsset).should('have.been.calledWith', 1, 4);
     });
@@ -690,7 +690,7 @@ describe('GalleryComponent', () => {
 
     mountGallery({ rateAsset }).then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.assets = [ratedAsset, mockAssets[1]];
+      component.assets.set([ratedAsset, mockAssets[1]]);
       component.rateAsset(ratedAsset, 4);
       cy.wrap(rateAsset).should('have.been.calledWith', 1, 0);
     });
@@ -814,7 +814,7 @@ describe('GalleryComponent', () => {
       component.currentFolder = '/photos';
       component.addTagFilter({ value: 'vacation', chipInput: { clear: () => {} } } as unknown as MatChipInputEvent);
       expect(component.selectedTags).to.deep.equal(['vacation']);
-      expect(component.pageIndex).to.equal(0);
+      expect(component.pageIndex()).to.equal(0);
     });
 
     cy.wrap(getAssets).should('have.been.called');
@@ -913,7 +913,7 @@ describe('GalleryComponent', () => {
       return Promise.resolve().then(() => {
         fixture.detectChanges();
         expect(fixture.componentInstance.viewMode).to.equal('viewer');
-        expect(fixture.componentInstance.currentViewerIndex).to.equal(1);
+        expect(fixture.componentInstance.currentViewerIndex()).to.equal(1);
       });
     });
   });
@@ -979,11 +979,11 @@ describe('GalleryComponent', () => {
       component.currentFolder = '/photos';
       component.setViewType('timeline');
       return Promise.resolve().then(() => {
-        component.timelineGroups = [{ localDate: '2024-05-10', label: 'May 10, 2024', assets: [] }];
+        component.timelineGroups.set([{ localDate: '2024-05-10', label: 'May 10, 2024', assets: [] }]);
         component.searchTerm = 'beach';
         component.loadAssets();
-        expect(component.timelineGroups).to.deep.equal([]);
-        expect(component.timelinePageIndex).to.equal(0);
+        expect(component.timelineGroups()).to.deep.equal([]);
+        expect(component.timelinePageIndex()).to.equal(0);
       });
     });
   });
@@ -991,7 +991,7 @@ describe('GalleryComponent', () => {
   it('should switch to thumbnails mode when a folder is selected while in viewer mode', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.assets = [...mockAssets];
+      component.assets.set([...mockAssets]);
       component.openViewer(0);
       expect(component.viewMode).to.equal('viewer');
 
@@ -1004,7 +1004,7 @@ describe('GalleryComponent', () => {
   it('should switch to thumbnails mode when a folder is selected while in slideshow mode', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.assets = [...mockAssets];
+      component.assets.set([...mockAssets]);
       component.startSlideshow(0);
       expect(component.viewMode).to.equal('slideshow');
 
@@ -1020,8 +1020,8 @@ describe('GalleryComponent', () => {
       const component = fixture.componentInstance;
       cy.stub(component['dialog'], 'open').returns({ afterClosed: () => of({ destinationFolder: '/target' }) } as never);
       component.currentFolder = '/photos';
-      component.selectedAssets.add(1);
-      component.selectedAssets.add(2);
+      component.selectedAssets.update(s => new Set(s).add(1));
+      component.selectedAssets.update(s => new Set(s).add(2));
       component.moveSelectedAssets('move');
       return Promise.resolve().then(() => fixture.detectChanges());
     });
@@ -1035,7 +1035,7 @@ describe('GalleryComponent', () => {
       const component = fixture.componentInstance;
       cy.stub(component['dialog'], 'open').returns({ afterClosed: () => of({ destinationFolder: '/target' }) } as never);
       component.currentFolder = '/photos';
-      component.selectedAssets.add(1);
+      component.selectedAssets.update(s => new Set(s).add(1));
       component.moveSelectedAssets('copy');
       return Promise.resolve().then(() => fixture.detectChanges());
     });
@@ -1049,7 +1049,7 @@ describe('GalleryComponent', () => {
       const component = fixture.componentInstance;
       cy.stub(component['dialog'], 'open').returns({ afterClosed: () => of({ destinationFolder: '/target' }) } as never);
       component.currentFolder = '/photos';
-      component.selectedAssets.add(1);
+      component.selectedAssets.update(s => new Set(s).add(1));
       component.moveSelectedAssets('move');
       return Promise.resolve().then(() => fixture.detectChanges());
     });
@@ -1215,8 +1215,8 @@ describe('GalleryComponent', () => {
   it('should show position 2 of total in the status bar in slideshow mode at the second asset', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.assets = [...mockAssets];
-      component.totalItems = 2;
+      component.assets.set([...mockAssets]);
+      component.totalItems.set(2);
       component.currentFolder = '/photos';
       component.startSlideshow(1);
       fixture.detectChanges();
@@ -1274,7 +1274,7 @@ describe('GalleryComponent', () => {
 
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.assets = [videoAsset];
+      component.assets.set([videoAsset]);
       component.openViewer(0);
       fixture.detectChanges();
     });
@@ -1286,7 +1286,7 @@ describe('GalleryComponent', () => {
   it('should show an img element instead of a video for an image asset in the viewer', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.assets = [...mockAssets];
+      component.assets.set([...mockAssets]);
       component.openViewer(0);
       fixture.detectChanges();
     });
@@ -1304,7 +1304,7 @@ describe('GalleryComponent', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
       component.currentFolder = '/photos';
-      component.selectedAssets = new Set([1, 2]);
+      component.selectedAssets.set(new Set([1, 2]));
       // Replace the injected dialog with the mock after mount
       (component as unknown as { dialog: MatDialog }).dialog = mockDialog as MatDialog;
       component.renameSelectedAssets();
@@ -1321,7 +1321,7 @@ describe('GalleryComponent', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
       component.currentFolder = '/photos';
-      component.selectedAssets = new Set([1]);
+      component.selectedAssets.set(new Set([1]));
       (component as unknown as { dialog: MatDialog }).dialog = mockDialog as MatDialog;
       component.renameSelectedAssets();
       fixture.detectChanges();
@@ -1336,7 +1336,7 @@ describe('GalleryComponent', () => {
     mountGallery().then(({ fixture }) => {
       const component = fixture.componentInstance;
       component.isDragging = true;
-      component.viewerZoom = 1;
+      component.viewerZoom.set(1);
       component.onViewerMouseMove(new MouseEvent('mousemove', { movementX: 30, movementY: 20 }));
       expect(component.panX).to.equal(30);
       expect(component.panY).to.equal(20);
@@ -1348,7 +1348,7 @@ describe('GalleryComponent', () => {
       const component = fixture.componentInstance;
       component.panX = 50;
       component.panY = 30;
-      component.viewerZoom = 2;
+      component.viewerZoom.set(2);
       component.resetZoom();
       expect(component.panX).to.equal(0);
       expect(component.panY).to.equal(0);

--- a/JPPhotoManagerWeb/frontend/src/app/features/gallery/gallery.component.html
+++ b/JPPhotoManagerWeb/frontend/src/app/features/gallery/gallery.component.html
@@ -1,9 +1,9 @@
 <mat-sidenav-container class="gallery-layout full-height">
 
   <mat-sidenav
-    [mode]="isMobile ? 'over' : 'side'"
-    [opened]="sidenavOpen"
-    (closedStart)="sidenavOpen = false"
+    [mode]="isMobile() ? 'over' : 'side'"
+    [opened]="sidenavOpen()"
+    (closedStart)="sidenavOpen.set(false)"
     class="folder-sidenav">
     <app-folder-nav (folderSelected)="onFolderSelected($event)" />
   </mat-sidenav>
@@ -12,7 +12,7 @@
 
     <!-- Toolbar -->
     <mat-toolbar class="gallery-toolbar">
-      @if (isMobile) {
+      @if (isMobile()) {
         <button mat-icon-button (click)="toggleSidenav()" aria-label="Toggle folder panel">
           <mat-icon>menu</mat-icon>
         </button>
@@ -76,7 +76,7 @@
           </mat-menu>
         }
 
-        @if (assets.length > 0) {
+        @if (assets().length > 0) {
           <button mat-icon-button (click)="startSlideshow(0)" title="Start slideshow">
             <mat-icon>slideshow</mat-icon>
           </button>
@@ -88,9 +88,9 @@
       }
 
       @if (viewMode === 'viewer') {
-        @if (!isMobile) {
+        @if (!isMobile()) {
           <button mat-icon-button (click)="zoomOut()" title="Zoom out"><mat-icon>zoom_out</mat-icon></button>
-          <button mat-icon-button (click)="resetZoom()" [disabled]="viewerZoom === 1" title="Reset zoom"><mat-icon>zoom_out_map</mat-icon></button>
+          <button mat-icon-button (click)="resetZoom()" [disabled]="viewerZoom() === 1" title="Reset zoom"><mat-icon>zoom_out_map</mat-icon></button>
           <button mat-icon-button (click)="zoomIn()" title="Zoom in"><mat-icon>zoom_in</mat-icon></button>
           @for (star of [1,2,3,4,5]; track star) {
             <button mat-icon-button (click)="rateCurrentAsset(star)">
@@ -105,7 +105,7 @@
           <button mat-icon-button (click)="toggleExifPanel()" [class.active]="showExifPanel" title="EXIF info">
             <mat-icon>info</mat-icon>
           </button>
-          <button mat-icon-button (click)="startSlideshow(currentViewerIndex)" title="Slideshow">
+          <button mat-icon-button (click)="startSlideshow(currentViewerIndex())" title="Slideshow">
             <mat-icon>slideshow</mat-icon>
           </button>
         } @else {
@@ -116,7 +116,7 @@
             <button mat-menu-item (click)="zoomOut()">
               <mat-icon>zoom_out</mat-icon> Zoom out
             </button>
-            <button mat-menu-item (click)="resetZoom()" [disabled]="viewerZoom === 1">
+            <button mat-menu-item (click)="resetZoom()" [disabled]="viewerZoom() === 1">
               <mat-icon>zoom_out_map</mat-icon> Reset zoom
             </button>
             <button mat-menu-item (click)="zoomIn()">
@@ -136,7 +136,7 @@
             <button mat-menu-item (click)="toggleExifPanel()">
               <mat-icon>info</mat-icon> EXIF info
             </button>
-            <button mat-menu-item (click)="startSlideshow(currentViewerIndex)">
+            <button mat-menu-item (click)="startSlideshow(currentViewerIndex())">
               <mat-icon>slideshow</mat-icon> Slideshow
             </button>
           </mat-menu>
@@ -145,8 +145,8 @@
       }
 
       @if (viewMode === 'slideshow') {
-        <button mat-icon-button (click)="toggleSlideshowPlay()" [title]="slideshowPlaying ? 'Pause' : 'Play'">
-          <mat-icon>{{ slideshowPlaying ? 'pause' : 'play_arrow' }}</mat-icon>
+        <button mat-icon-button (click)="toggleSlideshowPlay()" [title]="slideshowPlaying() ? 'Pause' : 'Play'">
+          <mat-icon>{{ slideshowPlaying() ? 'pause' : 'play_arrow' }}</mat-icon>
         </button>
         <mat-select [(ngModel)]="slideshowInterval" (ngModelChange)="onIntervalChange()" class="interval-select" title="Interval">
           @for (opt of intervalOptions; track opt) {
@@ -192,11 +192,11 @@
           <span class="filter-rating-label">{{ minRating > 0 ? minRating + '★ +' : 'Any rating' }}</span>
         </div>
 
-        <mat-select [(ngModel)]="selectedPresetId"
-                    (ngModelChange)="onPresetSelected($event)"
+        <mat-select [ngModel]="selectedPresetId()"
+                    (ngModelChange)="selectedPresetId.set($event); onPresetSelected($event)"
                     placeholder="Load preset"
                     class="preset-select">
-          @for (preset of presets; track preset.presetId) {
+          @for (preset of presets(); track preset.presetId) {
             <mat-option [value]="preset.presetId">
               {{ preset.name }}
               <button mat-icon-button class="preset-delete-btn"
@@ -242,7 +242,7 @@
           />
         </mat-chip-grid>
         <mat-autocomplete #tagFilterAuto="matAutocomplete" (optionSelected)="addTagFilterFromAutocomplete($event)">
-          @for (suggestion of tagSuggestions; track suggestion) {
+          @for (suggestion of tagSuggestions(); track suggestion) {
             <mat-option [value]="suggestion">{{ suggestion }}</mat-option>
           }
         </mat-autocomplete>
@@ -255,16 +255,16 @@
         @if (currentFolder && authService.isAdmin()) {
           <app-drop-zone [folderPath]="currentFolder" (uploadComplete)="onUploadComplete()" />
         }
-        @if (isLoading) {
+        @if (isLoading()) {
           <div class="loading-row">
             <mat-progress-bar mode="indeterminate" />
           </div>
         }
-        @if (!isLoading && assets.length === 0 && currentFolder) {
+        @if (!isLoading() && assets().length === 0 && currentFolder) {
           <div class="empty-state">No images found in this folder.</div>
         }
         <cdk-virtual-scroll-viewport itemSize="80" class="asset-virtual-viewport">
-          <div *cdkVirtualFor="let asset of assets; trackBy: trackByAssetId; let i = index"
+          <div *cdkVirtualFor="let asset of assets(); trackBy: trackByAssetId; let i = index"
                class="asset-list-row"
                [class.asset-list-row--selected]="isSelected(asset)"
                (click)="toggleSelection(asset)"
@@ -305,7 +305,7 @@
             </button>
           </div>
         </cdk-virtual-scroll-viewport>
-        @if (allLoaded && assets.length > 0) {
+        @if (allLoaded() && assets().length > 0) {
           <div class="end-of-list">All photos loaded</div>
         }
       </div>
@@ -314,13 +314,13 @@
     <!-- Timeline View -->
     @if (viewMode === 'thumbnails' && viewType === 'timeline') {
       <div class="timeline-view-container flex-1">
-        <app-timeline-view [groups]="timelineGroups" (thumbnailClick)="openViewerFromTimeline($event)" />
-        @if (isLoading) {
+        <app-timeline-view [groups]="timelineGroups()" (thumbnailClick)="openViewerFromTimeline($event)" />
+        @if (isLoading()) {
           <div class="loading-row">
             <mat-progress-bar mode="indeterminate" />
           </div>
         }
-        @if (timelineAllLoaded && timelineGroups.length > 0) {
+        @if (timelineAllLoaded() && timelineGroups().length > 0) {
           <div class="end-of-list">All photos loaded</div>
         }
       </div>
@@ -343,7 +343,7 @@
            (touchstart)="onViewerTouchStart($event)"
            (touchmove)="onViewerTouchMove($event)"
            (touchend)="onViewerTouchEnd()">
-          <button mat-icon-button class="viewer-nav viewer-nav--prev" (click)="viewerPrev()" [disabled]="currentViewerIndex === 0">
+          <button mat-icon-button class="viewer-nav viewer-nav--prev" (click)="viewerPrev()" [disabled]="currentViewerIndex() === 0">
             <mat-icon>chevron_left</mat-icon>
           </button>
           @if (currentViewerAsset.fileType === 'AUDIO') {
@@ -368,12 +368,12 @@
             <img
               [src]="currentViewerAsset.imageUrl"
               [alt]="currentViewerAsset.fileName"
-              [style.transform]="'scale(' + viewerZoom + ') translate(' + panX + 'px, ' + panY + 'px)'"
+              [style.transform]="'scale(' + viewerZoom() + ') translate(' + panX + 'px, ' + panY + 'px)'"
               class="viewer-image"
               draggable="false"
             />
           }
-          <button mat-icon-button class="viewer-nav viewer-nav--next" (click)="viewerNext()" [disabled]="currentViewerIndex >= assets.length - 1">
+          <button mat-icon-button class="viewer-nav viewer-nav--next" (click)="viewerNext()" [disabled]="currentViewerIndex() >= assets().length - 1">
             <mat-icon>chevron_right</mat-icon>
           </button>
         </div>
@@ -388,37 +388,37 @@
     <!-- Slideshow -->
     @if (viewMode === 'slideshow' && currentViewerAsset) {
       <div class="image-viewer flex-1">
-        <button mat-icon-button class="viewer-nav viewer-nav--prev" (click)="stepSlideshow(-1)" [disabled]="currentViewerIndex === 0">
+        <button mat-icon-button class="viewer-nav viewer-nav--prev" (click)="stepSlideshow(-1)" [disabled]="currentViewerIndex() === 0">
           <mat-icon>chevron_left</mat-icon>
         </button>
         <img
           [src]="currentViewerAsset.imageUrl"
           [alt]="currentViewerAsset.fileName"
         />
-        <button mat-icon-button class="viewer-nav viewer-nav--next" (click)="stepSlideshow(1)" [disabled]="currentViewerIndex >= assets.length - 1">
+        <button mat-icon-button class="viewer-nav viewer-nav--next" (click)="stepSlideshow(1)" [disabled]="currentViewerIndex() >= assets().length - 1">
           <mat-icon>chevron_right</mat-icon>
         </button>
       </div>
-      @if (slideshowResetTick) {
+      @if (slideshowResetTick()) {
         <div class="slideshow-progress-bar"
              [style.animation-duration]="slideshowInterval + 's'"
-             [style.animation-play-state]="slideshowPlaying ? 'running' : 'paused'">
+             [style.animation-play-state]="slideshowPlaying() ? 'running' : 'paused'">
         </div>
       } @else {
         <div class="slideshow-progress-bar"
              [style.animation-duration]="slideshowInterval + 's'"
-             [style.animation-play-state]="slideshowPlaying ? 'running' : 'paused'">
+             [style.animation-play-state]="slideshowPlaying() ? 'running' : 'paused'">
         </div>
       }
     }
 
     <!-- Status Bar -->
     <div class="status-bar">
-      @if (currentFolder && totalItems > 0) {
+      @if (currentFolder && totalItems() > 0) {
         @if (viewMode === 'viewer' || viewMode === 'slideshow') {
-          <span>{{ currentViewerIndex + 1 }} of {{ totalItems }} photos</span>
+          <span>{{ currentViewerIndex() + 1 }} of {{ totalItems() }} photos</span>
         } @else {
-          <span>{{ totalItems }} photos</span>
+          <span>{{ totalItems() }} photos</span>
         }
       } @else {
         <span>{{ currentFolder }}</span>
@@ -426,8 +426,8 @@
       @if (selectedCount > 0) {
         <span>{{ selectedCount }} selected</span>
       }
-      @if (statusMessage) {
-        <span>{{ statusMessage }}</span>
+      @if (statusMessage()) {
+        <span>{{ statusMessage() }}</span>
       }
     </div>
 

--- a/JPPhotoManagerWeb/frontend/src/app/features/gallery/gallery.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/gallery/gallery.component.ts
@@ -6,7 +6,8 @@ import {
   OnDestroy,
   OnInit,
   ViewChild,
-  ChangeDetectionStrategy
+  ChangeDetectionStrategy,
+  signal
 } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { CommonModule } from "@angular/common";
@@ -85,7 +86,7 @@ type ViewType = "grid" | "timeline";
     SocialMediaCropComponent,
   ],
   templateUrl: "./gallery.component.html",
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: "./gallery.component.scss",
 })
 export class GalleryComponent implements OnInit, OnDestroy {
@@ -96,8 +97,8 @@ export class GalleryComponent implements OnInit, OnDestroy {
   readonly audioPlayer = inject(MediaPlayerService);
   readonly authService = inject(AuthService);
 
-  isMobile = false;
-  sidenavOpen = true;
+  readonly isMobile = signal(false);
+  readonly sidenavOpen = signal(true);
 
   currentFolder: string = "";
   viewMode: ViewMode = "thumbnails";
@@ -109,36 +110,36 @@ export class GalleryComponent implements OnInit, OnDestroy {
   dateTo: Date | null = null;
   minRating = 0;
   selectedTags: string[] = [];
-  tagSuggestions: string[] = [];
+  readonly tagSuggestions = signal<string[]>([]);
   tagFilterControl = new FormControl<string>('', { nonNullable: true });
   readonly tagSeparatorKeysCodes = [ENTER, COMMA] as const;
   private readonly searchSubject = new Subject<string>();
   private catalogEventSource?: EventSource;
   private readonly destroy$ = new Subject<void>();
 
-  assets: Asset[] = [];
-  timelineGroups: TimelineGroup[] = [];
-  timelinePageIndex = 0;
-  timelineAllLoaded = false;
-  selectedAssets: Set<number> = new Set();
-  currentViewerIndex = 0;
-  viewerZoom = 1;
+  readonly assets = signal<Asset[]>([]);
+  readonly timelineGroups = signal<TimelineGroup[]>([]);
+  readonly timelinePageIndex = signal(0);
+  readonly timelineAllLoaded = signal(false);
+  readonly selectedAssets = signal<Set<number>>(new Set());
+  readonly currentViewerIndex = signal(0);
+  readonly viewerZoom = signal(1);
   slideshowInterval = 5;
-  slideshowPlaying = false;
+  readonly slideshowPlaying = signal(false);
   private pendingViewerAssetId: number | null = null;
   private slideshowTimer: ReturnType<typeof setInterval> | null = null;
-  slideshowResetTick = false;
+  readonly slideshowResetTick = signal(false);
   readonly intervalOptions = [3, 5, 10, 15];
-  userAlbums: AlbumSummary[] = [];
-  presets: SearchPreset[] = [];
-  selectedPresetId: number | null = null;
+  readonly userAlbums = signal<AlbumSummary[]>([]);
+  readonly presets = signal<SearchPreset[]>([]);
+  readonly selectedPresetId = signal<number | null>(null);
 
-  pageIndex = 0;
-  totalItems = 0;
-  isLoading = false;
-  allLoaded = false;
+  readonly pageIndex = signal(0);
+  readonly totalItems = signal(0);
+  readonly isLoading = signal(false);
+  readonly allLoaded = signal(false);
 
-  statusMessage = "";
+  readonly statusMessage = signal("");
   showExifPanel = false;
   showCropOverlay = false;
 
@@ -172,7 +173,7 @@ export class GalleryComponent implements OnInit, OnDestroy {
     this.searchSubject
       .pipe(debounceTime(400), distinctUntilChanged(), takeUntil(this.destroy$))
       .subscribe(() => {
-        this.pageIndex = 0;
+        this.pageIndex.set(0);
         this.loadAssets();
       });
 
@@ -183,10 +184,10 @@ export class GalleryComponent implements OnInit, OnDestroy {
     ).subscribe(q => {
       if (q && q.length >= 1) {
         this.tagService.searchTags(q).subscribe(tags => {
-          this.tagSuggestions = tags.filter(t => !this.selectedTags.includes(t));
+          this.tagSuggestions.set(tags.filter(t => !this.selectedTags.includes(t)));
         });
       } else {
-        this.tagSuggestions = [];
+        this.tagSuggestions.set([]);
       }
     });
 
@@ -194,8 +195,8 @@ export class GalleryComponent implements OnInit, OnDestroy {
       .observe([Breakpoints.Handset])
       .pipe(takeUntil(this.destroy$))
       .subscribe((result) => {
-        this.isMobile = result.matches;
-        this.sidenavOpen = !result.matches;
+        this.isMobile.set(result.matches);
+        this.sidenavOpen.set(!result.matches);
       });
 
     this.loadPresets();
@@ -219,20 +220,20 @@ export class GalleryComponent implements OnInit, OnDestroy {
   }
 
   toggleSidenav(): void {
-    this.sidenavOpen = !this.sidenavOpen;
+    this.sidenavOpen.update(open => !open);
   }
 
   onFolderSelected(folderPath: string): void {
     this.currentFolder = folderPath;
     this.viewMode = 'thumbnails';
-    if (this.isMobile) {
-      this.sidenavOpen = false;
+    if (this.isMobile()) {
+      this.sidenavOpen.set(false);
     }
     this.clearFilters();
-    this.selectedAssets.clear();
+    this.selectedAssets.set(new Set());
     this.disconnectObserver();
     this.albumService.getAlbums().subscribe({
-      next: (albums) => (this.userAlbums = albums),
+      next: (albums) => this.userAlbums.set(albums),
       error: () => {},
     });
     Promise.resolve().then(() => {
@@ -252,12 +253,12 @@ export class GalleryComponent implements OnInit, OnDestroy {
   }
 
   onDateChange(): void {
-    this.pageIndex = 0;
+    this.pageIndex.set(0);
     this.loadAssets();
   }
 
   onMinRatingChange(): void {
-    this.pageIndex = 0;
+    this.pageIndex.set(0);
     this.loadAssets();
   }
 
@@ -265,7 +266,9 @@ export class GalleryComponent implements OnInit, OnDestroy {
     const newRating = asset.rating === star ? 0 : star;
     this.assetService.rateAsset(asset.assetId, newRating).subscribe({
       next: () => {
-        asset.rating = newRating;
+        this.assets.update(list =>
+          list.map(a => (a.assetId === asset.assetId ? { ...a, rating: newRating } : a)),
+        );
       },
       error: () =>
         this.snackBar.open("Failed to rate asset", "Dismiss", {
@@ -286,20 +289,20 @@ export class GalleryComponent implements OnInit, OnDestroy {
     this.dateTo = null;
     this.minRating = 0;
     this.selectedTags = [];
-    this.tagSuggestions = [];
+    this.tagSuggestions.set([]);
     this.tagFilterControl.setValue('', { emitEvent: false });
-    this.assets = [];
-    this.pageIndex = 0;
-    this.isLoading = false;
-    this.allLoaded = false;
-    this.timelineGroups = [];
-    this.timelinePageIndex = 0;
-    this.timelineAllLoaded = false;
+    this.assets.set([]);
+    this.pageIndex.set(0);
+    this.isLoading.set(false);
+    this.allLoaded.set(false);
+    this.timelineGroups.set([]);
+    this.timelinePageIndex.set(0);
+    this.timelineAllLoaded.set(false);
   }
 
   loadNextPage(continueLoading = false): void {
-    if (this.isLoading || this.allLoaded || !this.currentFolder) return;
-    this.isLoading = true;
+    if (this.isLoading() || this.allLoaded() || !this.currentFolder) return;
+    this.isLoading.set(true);
     const search = this.searchTerm.trim() || undefined;
     const dateFrom = this.dateFrom
       ? this.dateFrom.toISOString().substring(0, 10)
@@ -312,7 +315,7 @@ export class GalleryComponent implements OnInit, OnDestroy {
     this.assetService
       .getAssets(
         this.currentFolder,
-        this.pageIndex,
+        this.pageIndex(),
         this.sortCriteria,
         search,
         dateFrom,
@@ -322,24 +325,24 @@ export class GalleryComponent implements OnInit, OnDestroy {
       )
       .subscribe({
         next: (data: PaginatedData<Asset>) => {
-          this.assets = [...this.assets, ...data.items];
-          this.totalItems = data.totalItems;
-          this.pageIndex++;
-          this.allLoaded = this.pageIndex >= data.totalPages;
-          this.isLoading = false;
+          this.assets.update(list => [...list, ...data.items]);
+          this.totalItems.set(data.totalItems);
+          this.pageIndex.update(i => i + 1);
+          this.allLoaded.set(this.pageIndex() >= data.totalPages);
+          this.isLoading.set(false);
           if (this.pendingViewerAssetId !== null) {
-            const idx = this.assets.findIndex(a => a.assetId === this.pendingViewerAssetId);
+            const idx = this.assets().findIndex(a => a.assetId === this.pendingViewerAssetId);
             if (idx >= 0) {
               this.pendingViewerAssetId = null;
               this.openViewer(idx);
             }
           }
-          if (continueLoading && !this.allLoaded) {
+          if (continueLoading && !this.allLoaded()) {
             this.loadNextPage(true);
           }
         },
         error: () => {
-          this.isLoading = false;
+          this.isLoading.set(false);
           this.snackBar.open("Failed to load assets", "Dismiss", {
             duration: 3000,
           });
@@ -365,22 +368,22 @@ export class GalleryComponent implements OnInit, OnDestroy {
   }
 
   loadTimelinePage(): void {
-    if (this.isLoading || this.timelineAllLoaded || !this.currentFolder) return;
-    this.isLoading = true;
+    if (this.isLoading() || this.timelineAllLoaded() || !this.currentFolder) return;
+    this.isLoading.set(true);
     const search = this.searchTerm.trim() || undefined;
     const dateFrom = this.dateFrom ? this.dateFrom.toISOString().substring(0, 10) : undefined;
     const dateTo = this.dateTo ? this.dateTo.toISOString().substring(0, 10) : undefined;
     const minRating = this.minRating > 0 ? this.minRating : undefined;
-    this.assetService.getTimeline(this.currentFolder, this.timelinePageIndex, { search, dateFrom, dateTo, minRating })
+    this.assetService.getTimeline(this.currentFolder, this.timelinePageIndex(), { search, dateFrom, dateTo, minRating })
       .subscribe({
         next: (data) => {
-          this.timelineGroups = [...this.timelineGroups, ...data.items];
-          this.timelinePageIndex++;
-          this.timelineAllLoaded = this.timelinePageIndex >= data.totalPages;
-          this.isLoading = false;
+          this.timelineGroups.update(list => [...list, ...data.items]);
+          this.timelinePageIndex.update(i => i + 1);
+          this.timelineAllLoaded.set(this.timelinePageIndex() >= data.totalPages);
+          this.isLoading.set(false);
         },
         error: () => {
-          this.isLoading = false;
+          this.isLoading.set(false);
           this.snackBar.open('Failed to load timeline', 'Dismiss', { duration: 3000 });
         },
       });
@@ -391,15 +394,15 @@ export class GalleryComponent implements OnInit, OnDestroy {
     this.viewType = type;
     this.disconnectObserver();
     if (type === 'timeline') {
-      this.timelineGroups = [];
-      this.timelinePageIndex = 0;
-      this.timelineAllLoaded = false;
-      this.isLoading = false;
+      this.timelineGroups.set([]);
+      this.timelinePageIndex.set(0);
+      this.timelineAllLoaded.set(false);
+      this.isLoading.set(false);
     } else {
-      this.assets = [];
-      this.pageIndex = 0;
-      this.isLoading = false;
-      this.allLoaded = false;
+      this.assets.set([]);
+      this.pageIndex.set(0);
+      this.isLoading.set(false);
+      this.allLoaded.set(false);
     }
     Promise.resolve().then(() => {
       if (type === 'timeline') {
@@ -417,13 +420,13 @@ export class GalleryComponent implements OnInit, OnDestroy {
   }
 
   loadAssets(): void {
-    this.assets = [];
-    this.pageIndex = 0;
-    this.isLoading = false;
-    this.allLoaded = false;
-    this.timelineGroups = [];
-    this.timelinePageIndex = 0;
-    this.timelineAllLoaded = false;
+    this.assets.set([]);
+    this.pageIndex.set(0);
+    this.isLoading.set(false);
+    this.allLoaded.set(false);
+    this.timelineGroups.set([]);
+    this.timelinePageIndex.set(0);
+    this.timelineAllLoaded.set(false);
     this.disconnectObserver();
     Promise.resolve().then(() => {
       if (this.viewType === 'timeline') {
@@ -436,30 +439,34 @@ export class GalleryComponent implements OnInit, OnDestroy {
   }
 
   toggleSelection(asset: Asset): void {
-    if (this.selectedAssets.has(asset.assetId)) {
-      this.selectedAssets.delete(asset.assetId);
-    } else {
-      this.selectedAssets.add(asset.assetId);
-    }
+    this.selectedAssets.update(selected => {
+      const next = new Set(selected);
+      if (next.has(asset.assetId)) {
+        next.delete(asset.assetId);
+      } else {
+        next.add(asset.assetId);
+      }
+      return next;
+    });
   }
 
   isSelected(asset: Asset): boolean {
-    return this.selectedAssets.has(asset.assetId);
+    return this.selectedAssets().has(asset.assetId);
   }
 
   openViewer(index: number): void {
-    this.currentViewerIndex = index;
+    this.currentViewerIndex.set(index);
     this.viewMode = "viewer";
-    this.viewerZoom = 1;
+    this.viewerZoom.set(1);
     this.panX = 0;
     this.panY = 0;
     this.showExifPanel = false;
   }
 
   openViewerFromTimeline(asset: Asset): void {
-    const flat = this.timelineGroups.flatMap(g => g.assets);
+    const flat = this.timelineGroups().flatMap(g => g.assets);
     const idx = flat.findIndex(a => a.assetId === asset.assetId);
-    this.assets = flat;
+    this.assets.set(flat);
     this.openViewer(idx >= 0 ? idx : 0);
   }
 
@@ -510,10 +517,10 @@ export class GalleryComponent implements OnInit, OnDestroy {
   }
 
   startSlideshow(index: number): void {
-    this.currentViewerIndex = index;
-    this.viewerZoom = 1;
+    this.currentViewerIndex.set(index);
+    this.viewerZoom.set(1);
     this.viewMode = "slideshow";
-    this.slideshowPlaying = true;
+    this.slideshowPlaying.set(true);
     this.slideshowTimer = setInterval(
       () => this.advanceSlideshow(),
       this.slideshowInterval * 1000,
@@ -521,15 +528,15 @@ export class GalleryComponent implements OnInit, OnDestroy {
   }
 
   advanceSlideshow(): void {
-    if (this.currentViewerIndex < this.assets.length - 1) {
-      this.currentViewerIndex++;
-      this.viewerZoom = 1;
-      this.slideshowResetTick = !this.slideshowResetTick;
+    if (this.currentViewerIndex() < this.assets().length - 1) {
+      this.currentViewerIndex.update(i => i + 1);
+      this.viewerZoom.set(1);
+      this.slideshowResetTick.update(t => !t);
     } else {
       this.stopSlideshow();
-      this.statusMessage = "Slideshow complete";
+      this.statusMessage.set("Slideshow complete");
       setTimeout(() => {
-        this.statusMessage = "";
+        this.statusMessage.set("");
       }, 3000);
     }
   }
@@ -538,12 +545,12 @@ export class GalleryComponent implements OnInit, OnDestroy {
     if (this.slideshowTimer !== null) {
       clearInterval(this.slideshowTimer);
       this.slideshowTimer = null;
-      this.slideshowPlaying = false;
+      this.slideshowPlaying.set(false);
     }
   }
 
   resumeSlideshow(): void {
-    this.slideshowPlaying = true;
+    this.slideshowPlaying.set(true);
     this.slideshowTimer = setInterval(
       () => this.advanceSlideshow(),
       this.slideshowInterval * 1000,
@@ -551,7 +558,7 @@ export class GalleryComponent implements OnInit, OnDestroy {
   }
 
   toggleSlideshowPlay(): void {
-    if (this.slideshowPlaying) {
+    if (this.slideshowPlaying()) {
       this.pauseSlideshow();
     } else {
       this.resumeSlideshow();
@@ -560,7 +567,7 @@ export class GalleryComponent implements OnInit, OnDestroy {
 
   stopSlideshow(): void {
     this.pauseSlideshow();
-    this.slideshowPlaying = false;
+    this.slideshowPlaying.set(false);
   }
 
   exitSlideshow(): void {
@@ -578,11 +585,11 @@ export class GalleryComponent implements OnInit, OnDestroy {
   }
 
   onIntervalChange(): void {
-    if (this.slideshowPlaying) {
+    if (this.slideshowPlaying()) {
       this.pauseSlideshow();
       this.resumeSlideshow();
     }
-    this.slideshowResetTick = !this.slideshowResetTick;
+    this.slideshowResetTick.update(t => !t);
   }
 
   toggleExifPanel(): void {
@@ -590,37 +597,37 @@ export class GalleryComponent implements OnInit, OnDestroy {
   }
 
   viewerPrev(): void {
-    if (this.currentViewerIndex > 0) {
-      this.currentViewerIndex--;
-      this.viewerZoom = 1;
+    if (this.currentViewerIndex() > 0) {
+      this.currentViewerIndex.update(i => i - 1);
+      this.viewerZoom.set(1);
       this.panX = 0;
       this.panY = 0;
     }
   }
 
   viewerNext(): void {
-    if (this.currentViewerIndex < this.assets.length - 1) {
-      this.currentViewerIndex++;
-      this.viewerZoom = 1;
+    if (this.currentViewerIndex() < this.assets().length - 1) {
+      this.currentViewerIndex.update(i => i + 1);
+      this.viewerZoom.set(1);
       this.panX = 0;
       this.panY = 0;
     }
   }
 
   zoomIn(): void {
-    this.viewerZoom = Math.min(this.viewerZoom + 0.25, 4);
+    this.viewerZoom.update(z => Math.min(z + 0.25, 4));
   }
 
   zoomOut(): void {
-    this.viewerZoom = Math.max(this.viewerZoom - 0.25, 0.25);
-    if (this.viewerZoom === 1) {
+    this.viewerZoom.update(z => Math.max(z - 0.25, 0.25));
+    if (this.viewerZoom() === 1) {
       this.panX = 0;
       this.panY = 0;
     }
   }
 
   resetZoom(): void {
-    this.viewerZoom = 1;
+    this.viewerZoom.set(1);
     this.panX = 0;
     this.panY = 0;
   }
@@ -637,10 +644,10 @@ export class GalleryComponent implements OnInit, OnDestroy {
   }
 
   onSortChange(): void {
-    this.assets = [];
-    this.pageIndex = 0;
-    this.isLoading = false;
-    this.allLoaded = false;
+    this.assets.set([]);
+    this.pageIndex.set(0);
+    this.isLoading.set(false);
+    this.allLoaded.set(false);
     this.disconnectObserver();
     Promise.resolve().then(() => {
       this.loadNextPage(true);
@@ -648,7 +655,7 @@ export class GalleryComponent implements OnInit, OnDestroy {
   }
 
   downloadSelected(): void {
-    const ids = Array.from(this.selectedAssets);
+    const ids = Array.from(this.selectedAssets());
     if (ids.length === 0) return;
 
     const snackRef = this.snackBar.open("Preparing download…", undefined, {
@@ -676,12 +683,12 @@ export class GalleryComponent implements OnInit, OnDestroy {
   }
 
   deleteSelected(deleteFiles: boolean): void {
-    const ids = Array.from(this.selectedAssets);
+    const ids = Array.from(this.selectedAssets());
     if (ids.length === 0) return;
 
     this.assetService.deleteAssets(ids, deleteFiles).subscribe({
       next: () => {
-        this.selectedAssets.clear();
+        this.selectedAssets.set(new Set());
         this.loadAssets();
         this.snackBar.open(`Deleted ${ids.length} asset(s)`, undefined, {
           duration: 2000,
@@ -701,14 +708,14 @@ export class GalleryComponent implements OnInit, OnDestroy {
       AddToAlbumDialogResult
     >(AddToAlbumDialogComponent, {
       width: "400px",
-      data: { albums: this.userAlbums },
+      data: { albums: this.userAlbums() },
     });
     dialogRef.afterClosed().subscribe((result) => {
       if (!result) return;
       if (result.newAlbumName) {
         this.albumService.createAlbum({ name: result.newAlbumName }).subscribe({
           next: (album) => {
-            this.userAlbums = [...this.userAlbums, album];
+            this.userAlbums.update(list => [...list, album]);
             this.albumService
               .addAssets(album.albumId, [asset.assetId])
               .subscribe({
@@ -730,7 +737,7 @@ export class GalleryComponent implements OnInit, OnDestroy {
       } else if (result.albumId) {
         this.albumService.addAssets(result.albumId, [asset.assetId]).subscribe({
           next: () => {
-            const album = this.userAlbums.find(
+            const album = this.userAlbums().find(
               (a) => a.albumId === result.albumId,
             );
             this.snackBar.open(
@@ -751,12 +758,12 @@ export class GalleryComponent implements OnInit, OnDestroy {
   loadPresets(): void {
     this.searchPresetService
       .listPresets()
-      .subscribe({ next: (p) => (this.presets = p) });
+      .subscribe({ next: (p) => this.presets.set(p) });
   }
 
   onPresetSelected(presetId: number | null): void {
     if (presetId === null) return;
-    const preset = this.presets.find((p) => p.presetId === presetId);
+    const preset = this.presets().find((p) => p.presetId === presetId);
     if (preset) this.applyPreset(preset);
   }
 
@@ -765,7 +772,7 @@ export class GalleryComponent implements OnInit, OnDestroy {
     this.dateFrom = preset.dateFrom ? new Date(preset.dateFrom) : null;
     this.dateTo = preset.dateTo ? new Date(preset.dateTo) : null;
     this.minRating = preset.minRating ?? 0;
-    this.pageIndex = 0;
+    this.pageIndex.set(0);
     this.loadAssets();
   }
 
@@ -791,7 +798,7 @@ export class GalleryComponent implements OnInit, OnDestroy {
       };
       this.searchPresetService.createPreset(req).subscribe({
         next: (preset) => {
-          this.presets = [...this.presets, preset];
+          this.presets.update(list => [...list, preset]);
           this.snackBar.open("Preset saved", undefined, { duration: 2000 });
         },
       });
@@ -802,11 +809,9 @@ export class GalleryComponent implements OnInit, OnDestroy {
     event.stopPropagation();
     this.searchPresetService.deletePreset(preset.presetId).subscribe({
       next: () => {
-        this.presets = this.presets.filter(
-          (p) => p.presetId !== preset.presetId,
-        );
-        if (this.selectedPresetId === preset.presetId) {
-          this.selectedPresetId = null;
+        this.presets.update(list => list.filter((p) => p.presetId !== preset.presetId));
+        if (this.selectedPresetId() === preset.presetId) {
+          this.selectedPresetId.set(null);
         }
         this.snackBar.open("Preset deleted", undefined, { duration: 2000 });
       },
@@ -819,28 +824,28 @@ export class GalleryComponent implements OnInit, OnDestroy {
     this.tagFilterControl.setValue('', { emitEvent: false });
     if (!name || this.selectedTags.includes(name)) return;
     this.selectedTags = [...this.selectedTags, name];
-    this.pageIndex = 0;
+    this.pageIndex.set(0);
     this.loadAssets();
   }
 
   addTagFilterFromAutocomplete(event: MatAutocompleteSelectedEvent): void {
     const name = event.option.viewValue.toLowerCase();
     this.tagFilterControl.setValue('', { emitEvent: false });
-    this.tagSuggestions = [];
+    this.tagSuggestions.set([]);
     if (!name || this.selectedTags.includes(name)) return;
     this.selectedTags = [...this.selectedTags, name];
-    this.pageIndex = 0;
+    this.pageIndex.set(0);
     this.loadAssets();
   }
 
   removeTagFilter(name: string): void {
     this.selectedTags = this.selectedTags.filter(t => t !== name);
-    this.pageIndex = 0;
+    this.pageIndex.set(0);
     this.loadAssets();
   }
 
   openBulkTagDialog(): void {
-    const ids = Array.from(this.selectedAssets);
+    const ids = Array.from(this.selectedAssets());
     if (ids.length === 0) return;
     this.dialog.open<BulkTagDialogComponent, unknown, boolean>(BulkTagDialogComponent, {
       width: '440px',
@@ -851,14 +856,14 @@ export class GalleryComponent implements OnInit, OnDestroy {
   }
 
   renameSelectedAssets(): void {
-    const ids = Array.from(this.selectedAssets);
+    const ids = Array.from(this.selectedAssets());
     if (ids.length === 0) return;
     this.dialog.open(BatchRenameDialogComponent, {
       data: { assetIds: ids, assetCount: ids.length },
     }).afterClosed().subscribe((result: { success: boolean; count?: number; error?: string } | null) => {
       if (!result) return;
       if (result.success) {
-        this.selectedAssets.clear();
+        this.selectedAssets.set(new Set());
         this.loadAssets();
         this.snackBar.open(`Renamed ${result.count} asset(s)`, undefined, { duration: 2000 });
       } else {
@@ -868,7 +873,7 @@ export class GalleryComponent implements OnInit, OnDestroy {
   }
 
   moveSelectedAssets(mode: 'move' | 'copy'): void {
-    const ids = Array.from(this.selectedAssets);
+    const ids = Array.from(this.selectedAssets());
     if (ids.length === 0) return;
     this.dialog.open<
       FolderPickerDialogComponent,
@@ -887,7 +892,7 @@ export class GalleryComponent implements OnInit, OnDestroy {
           const folderName = result.destinationFolder.split('/').filter(Boolean).pop() ?? result.destinationFolder;
           const doneVerb = mode === 'move' ? 'Moved' : 'Copied';
           this.snackBar.open(`${doneVerb} ${ids.length} asset(s) to ${folderName}`, 'OK', { duration: 4000 });
-          this.selectedAssets.clear();
+          this.selectedAssets.set(new Set());
           this.loadAssets();
         },
         error: () => {
@@ -906,8 +911,8 @@ export class GalleryComponent implements OnInit, OnDestroy {
 
   onViewerMouseMove(event: MouseEvent): void {
     if (!this.isDragging) return;
-    this.panX += event.movementX / this.viewerZoom;
-    this.panY += event.movementY / this.viewerZoom;
+    this.panX += event.movementX / this.viewerZoom();
+    this.panY += event.movementY / this.viewerZoom();
   }
 
   onViewerMouseUp(): void {
@@ -927,8 +932,8 @@ export class GalleryComponent implements OnInit, OnDestroy {
   onViewerTouchMove(event: TouchEvent): void {
     const dx = event.touches[0].clientX - this.lastTouchX;
     const dy = event.touches[0].clientY - this.lastTouchY;
-    this.panX += dx / this.viewerZoom;
-    this.panY += dy / this.viewerZoom;
+    this.panX += dx / this.viewerZoom();
+    this.panY += dy / this.viewerZoom();
     this.lastTouchX = event.touches[0].clientX;
     this.lastTouchY = event.touches[0].clientY;
     event.preventDefault();
@@ -980,10 +985,10 @@ export class GalleryComponent implements OnInit, OnDestroy {
   }
 
   get currentViewerAsset(): Asset | undefined {
-    return this.assets[this.currentViewerIndex];
+    return this.assets()[this.currentViewerIndex()];
   }
 
   get selectedCount(): number {
-    return this.selectedAssets.size;
+    return this.selectedAssets().size;
   }
 }

--- a/JPPhotoManagerWeb/frontend/src/app/features/gallery/save-preset-dialog/save-preset-dialog.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/gallery/save-preset-dialog/save-preset-dialog.component.ts
@@ -9,7 +9,7 @@ import { MatInputModule } from '@angular/material/input';
   selector: 'app-save-preset-dialog',
   standalone: true,
   imports: [FormsModule, MatDialogModule, MatButtonModule, MatFormFieldModule, MatInputModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <h2 mat-dialog-title>Save Filter Preset</h2>
     <mat-dialog-content>

--- a/JPPhotoManagerWeb/frontend/src/app/features/gallery/social-media-crop/social-media-crop.component.html
+++ b/JPPhotoManagerWeb/frontend/src/app/features/gallery/social-media-crop/social-media-crop.component.html
@@ -13,9 +13,9 @@
 
     <button mat-raised-button
             color="primary"
-            [disabled]="isSaving"
+            [disabled]="isSaving()"
             (click)="saveAndDownload()">
-      {{ isSaving ? 'Saving…' : 'Save & Download' }}
+      {{ isSaving() ? 'Saving…' : 'Save & Download' }}
     </button>
 
     <button mat-button (click)="cancelled.emit()">Cancel</button>

--- a/JPPhotoManagerWeb/frontend/src/app/features/gallery/social-media-crop/social-media-crop.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/gallery/social-media-crop/social-media-crop.component.ts
@@ -7,7 +7,8 @@ import {
   OnDestroy,
   Output,
   ViewChild,
-  ChangeDetectionStrategy
+  ChangeDetectionStrategy,
+  signal
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
@@ -32,7 +33,7 @@ type CornerName = 'TL' | 'TR' | 'BL' | 'BR';
   standalone: true,
   imports: [FormsModule, MatButtonModule, MatSelectModule],
   templateUrl: './social-media-crop.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './social-media-crop.component.scss',
 })
 export class SocialMediaCropComponent implements AfterViewInit, OnDestroy {
@@ -43,7 +44,7 @@ export class SocialMediaCropComponent implements AfterViewInit, OnDestroy {
 
   readonly formats = SOCIAL_MEDIA_FORMATS;
   selectedFormat: SocialMediaFormatDef = SOCIAL_MEDIA_FORMATS[0];
-  isSaving = false;
+  readonly isSaving = signal(false);
 
   private readonly img = new Image();
   private cropBox: CropBox = { x: 0, y: 0, width: 0, height: 0 };
@@ -130,15 +131,15 @@ export class SocialMediaCropComponent implements AfterViewInit, OnDestroy {
       height: Math.round(this.cropBox.height * scaleY),
     };
 
-    this.isSaving = true;
+    this.isSaving.set(true);
     this.assetService.cropAsset(this.asset.assetId, request).subscribe({
       next: (newAsset) => {
-        this.isSaving = false;
+        this.isSaving.set(false);
         window.open('/api/assets/' + newAsset.assetId + '/image', '_blank');
         this.cancelled.emit();
       },
       error: () => {
-        this.isSaving = false;
+        this.isSaving.set(false);
         this.snackBar.open('Failed to save crop', 'Dismiss', { duration: 4000 });
       },
     });

--- a/JPPhotoManagerWeb/frontend/src/app/features/gallery/timeline-view/timeline-view.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/gallery/timeline-view/timeline-view.component.ts
@@ -8,7 +8,7 @@ import { Asset } from '../../../core/models/asset.model';
   standalone: true,
   imports: [ThumbnailComponent],
   templateUrl: './timeline-view.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './timeline-view.component.scss',
 })
 export class TimelineViewComponent {

--- a/JPPhotoManagerWeb/frontend/src/app/features/gallery/video-player/video-player.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/gallery/video-player/video-player.component.ts
@@ -8,7 +8,7 @@ import { MediaPlayerService } from '../../../core/services/media-player.service'
   standalone: true,
   imports: [MatButtonModule, MatIconModule],
   templateUrl: './video-player.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './video-player.component.scss',
 })
 export class VideoPlayerComponent implements AfterViewInit, OnDestroy {

--- a/JPPhotoManagerWeb/frontend/src/app/features/home/home.component.html
+++ b/JPPhotoManagerWeb/frontend/src/app/features/home/home.component.html
@@ -16,15 +16,15 @@
       Run Sync
     </button>
     <button mat-raised-button routerLink="/duplicates"
-            [matBadge]="$safeNavigationMigration(stats?.duplicateCount)"
-            [matBadgeHidden]="!stats || stats.duplicateCount === 0"
+            [matBadge]="$safeNavigationMigration(stats()?.duplicateCount)"
+            [matBadgeHidden]="!stats() || stats()?.duplicateCount === 0"
             matBadgeColor="warn">
       <mat-icon>content_copy</mat-icon>
       Find Duplicates
     </button>
   </div>
 
-  @if (stats) {
+  @if (stats(); as stats) {
     <!-- Library stat cards -->
     <div class="stats-grid">
       <mat-card class="stat-card">

--- a/JPPhotoManagerWeb/frontend/src/app/features/home/home.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/home/home.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, signal } from '@angular/core';
 import { DatePipe } from '@angular/common';
 import { Router, RouterLink } from '@angular/router';
 import { MatCardModule } from '@angular/material/card';
@@ -28,11 +28,11 @@ import { Asset } from '../../core/models/asset.model';
     FileSizePipe,
   ],
   templateUrl: './home.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './home.component.scss'
 })
 export class HomeComponent implements OnInit {
-  stats: HomeStats | null = null;
+  readonly stats = signal<HomeStats | null>(null);
 
   constructor(
     private homeService: HomeService,
@@ -41,13 +41,15 @@ export class HomeComponent implements OnInit {
 
   ngOnInit(): void {
     this.homeService.getStats().subscribe({
-      next: stats => (this.stats = stats)
+      next: stats => this.stats.set(stats),
+      error: () => {}
     });
   }
 
   get maxFolderCount(): number {
-    if (!this.stats?.topFolders?.length) return 1;
-    return this.stats.topFolders[0].assetCount;
+    const stats = this.stats();
+    if (!stats?.topFolders?.length) return 1;
+    return stats.topFolders[0].assetCount;
   }
 
   navigateToGalleryFolder(asset: AssetSummary): void {

--- a/JPPhotoManagerWeb/frontend/src/app/features/profile/sessions/sessions.component.html
+++ b/JPPhotoManagerWeb/frontend/src/app/features/profile/sessions/sessions.component.html
@@ -4,8 +4,8 @@
       <mat-card-title>Active Sessions</mat-card-title>
     </mat-card-header>
     <mat-card-content>
-      @if (errorMessage) {
-        <p class="error-message">{{ errorMessage }}</p>
+      @if (errorMessage()) {
+        <p class="error-message">{{ errorMessage() }}</p>
       }
 
       <div class="toolbar">
@@ -14,7 +14,7 @@
         </button>
       </div>
 
-      <table mat-table [dataSource]="sessions" class="sessions-table">
+      <table mat-table [dataSource]="sessions()" class="sessions-table">
         <ng-container matColumnDef="deviceHint">
           <th mat-header-cell *matHeaderCellDef>Device</th>
           <td mat-cell *matCellDef="let session">
@@ -44,7 +44,7 @@
         <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
       </table>
 
-      @if (sessions.length === 0) {
+      @if (sessions().length === 0) {
         <p class="no-sessions">No active sessions found.</p>
       }
     </mat-card-content>

--- a/JPPhotoManagerWeb/frontend/src/app/features/profile/sessions/sessions.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/profile/sessions/sessions.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatTableModule } from '@angular/material/table';
 import { MatButtonModule } from '@angular/material/button';
@@ -15,13 +15,13 @@ import { ConfirmDialogComponent } from '../../../shared/components/confirm-dialo
   standalone: true,
   imports: [CommonModule, MatTableModule, MatButtonModule, MatIconModule, MatCardModule],
   templateUrl: './sessions.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './sessions.component.scss'
 })
 export class SessionsComponent implements OnInit {
-  sessions: SessionInfo[] = [];
+  readonly sessions = signal<SessionInfo[]>([]);
   displayedColumns = ['deviceHint', 'lastUsedAt', 'actions'];
-  errorMessage: string | null = null;
+  readonly errorMessage = signal<string | null>(null);
 
   constructor(
     private authService: AuthService,
@@ -35,16 +35,16 @@ export class SessionsComponent implements OnInit {
 
   loadSessions(): void {
     this.authService.getSessions().subscribe({
-      next: sessions => (this.sessions = sessions),
-      error: () => (this.errorMessage = 'Failed to load sessions.')
+      next: sessions => this.sessions.set(sessions),
+      error: () => this.errorMessage.set('Failed to load sessions.')
     });
   }
 
   revokeSession(session: SessionInfo): void {
     this.authService.revokeSession(session.id).subscribe({
       next: () => {
-        this.sessions = this.sessions.filter(s => s.id !== session.id);
-        this.errorMessage = null;
+        this.sessions.update(list => list.filter(s => s.id !== session.id));
+        this.errorMessage.set(null);
         this.snackBar.open('Session revoked', undefined, { duration: 2000 });
       },
       error: () => this.snackBar.open('Failed to revoke session', 'Dismiss', { duration: 3000 })
@@ -66,8 +66,8 @@ export class SessionsComponent implements OnInit {
       if (!confirmed) return;
       this.authService.revokeAllOtherSessions().subscribe({
         next: () => {
-          this.sessions = this.sessions.filter(s => s.current);
-          this.errorMessage = null;
+          this.sessions.update(list => list.filter(s => s.current));
+          this.errorMessage.set(null);
           this.snackBar.open('Signed out of all other sessions', undefined, { duration: 2000 });
         },
         error: () => this.snackBar.open('Failed to sign out of other sessions', 'Dismiss', { duration: 3000 })

--- a/JPPhotoManagerWeb/frontend/src/app/features/recycle-bin/recycle-bin.component.html
+++ b/JPPhotoManagerWeb/frontend/src/app/features/recycle-bin/recycle-bin.component.html
@@ -21,7 +21,7 @@
 
   <div class="thumbnail-grid-container flex-1">
     <div class="thumbnail-grid">
-      @for (asset of assets; track asset.assetId) {
+      @for (asset of assets(); track asset.assetId) {
         <div class="asset-cell" (click)="toggleSelection(asset)">
           <app-thumbnail
             [asset]="asset"
@@ -29,19 +29,19 @@
           />
         </div>
       }
-      @if (assets.length === 0) {
+      @if (assets().length === 0) {
         <div class="empty-state">Recycle bin is empty.</div>
       }
     </div>
   </div>
 
-  @if (totalPages > 1) {
+  @if (totalPages() > 1) {
     <div class="pagination-bar">
-      <button mat-icon-button [disabled]="pageIndex === 0" (click)="loadPage(pageIndex - 1)">
+      <button mat-icon-button [disabled]="pageIndex() === 0" (click)="loadPage(pageIndex() - 1)">
         <mat-icon>chevron_left</mat-icon>
       </button>
-      <span>Page {{ pageIndex + 1 }} of {{ totalPages }}</span>
-      <button mat-icon-button [disabled]="pageIndex >= totalPages - 1" (click)="loadPage(pageIndex + 1)">
+      <span>Page {{ pageIndex() + 1 }} of {{ totalPages() }}</span>
+      <button mat-icon-button [disabled]="pageIndex() >= totalPages() - 1" (click)="loadPage(pageIndex() + 1)">
         <mat-icon>chevron_right</mat-icon>
       </button>
     </div>

--- a/JPPhotoManagerWeb/frontend/src/app/features/recycle-bin/recycle-bin.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/recycle-bin/recycle-bin.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, signal } from '@angular/core';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -18,16 +18,16 @@ import { PaginatedData } from '../../core/models/paginated-data.model';
     ThumbnailComponent
   ],
   templateUrl: './recycle-bin.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './recycle-bin.component.scss'
 })
 export class RecycleBinComponent implements OnInit {
 
-  assets: Asset[] = [];
-  selectedAssets = new Set<number>();
-  pageIndex = 0;
-  totalPages = 0;
-  totalItems = 0;
+  readonly assets = signal<Asset[]>([]);
+  readonly selectedAssets = signal<Set<number>>(new Set());
+  readonly pageIndex = signal(0);
+  readonly totalPages = signal(0);
+  readonly totalItems = signal(0);
 
   constructor(
     private recycleBinService: RecycleBinService,
@@ -41,33 +41,37 @@ export class RecycleBinComponent implements OnInit {
   loadPage(page: number): void {
     this.recycleBinService.getRecycleBin(page).subscribe({
       next: (data: PaginatedData<Asset>) => {
-        this.assets = data.items;
-        this.pageIndex = data.pageIndex;
-        this.totalPages = data.totalPages;
-        this.totalItems = Number(data.totalItems);
+        this.assets.set(data.items);
+        this.pageIndex.set(data.pageIndex);
+        this.totalPages.set(data.totalPages);
+        this.totalItems.set(Number(data.totalItems));
       },
       error: () => this.snackBar.open('Failed to load recycle bin', 'Dismiss', { duration: 3000 })
     });
   }
 
   toggleSelection(asset: Asset): void {
-    if (this.selectedAssets.has(asset.assetId)) {
-      this.selectedAssets.delete(asset.assetId);
-    } else {
-      this.selectedAssets.add(asset.assetId);
-    }
+    this.selectedAssets.update(selected => {
+      const next = new Set(selected);
+      if (next.has(asset.assetId)) {
+        next.delete(asset.assetId);
+      } else {
+        next.add(asset.assetId);
+      }
+      return next;
+    });
   }
 
   isSelected(asset: Asset): boolean {
-    return this.selectedAssets.has(asset.assetId);
+    return this.selectedAssets().has(asset.assetId);
   }
 
   restoreSelected(): void {
-    const ids = Array.from(this.selectedAssets);
+    const ids = Array.from(this.selectedAssets());
     this.recycleBinService.restoreAssets(ids).subscribe({
       next: () => {
         this.snackBar.open('Restored successfully', undefined, { duration: 2000 });
-        this.selectedAssets.clear();
+        this.selectedAssets.set(new Set());
         this.loadPage(0);
       },
       error: () => this.snackBar.open('Failed to restore assets', 'Dismiss', { duration: 3000 })
@@ -75,11 +79,11 @@ export class RecycleBinComponent implements OnInit {
   }
 
   purgeSelected(): void {
-    const ids = Array.from(this.selectedAssets);
+    const ids = Array.from(this.selectedAssets());
     this.recycleBinService.purgeAssets(ids).subscribe({
       next: () => {
         this.snackBar.open('Permanently deleted', undefined, { duration: 2000 });
-        this.selectedAssets.clear();
+        this.selectedAssets.set(new Set());
         this.loadPage(0);
       },
       error: () => this.snackBar.open('Failed to delete assets', 'Dismiss', { duration: 3000 })
@@ -97,6 +101,6 @@ export class RecycleBinComponent implements OnInit {
   }
 
   get selectedCount(): number {
-    return this.selectedAssets.size;
+    return this.selectedAssets().size;
   }
 }

--- a/JPPhotoManagerWeb/frontend/src/app/features/sync/sync.component.cy.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/sync/sync.component.cy.ts
@@ -48,7 +48,7 @@ describe('SyncComponent', () => {
 
   it('should start on the configure step', () => {
     mountComponent().then(({ fixture }) => {
-      expect(fixture.componentInstance.step).to.equal('configure');
+      expect(fixture.componentInstance.step()).to.equal('configure');
     });
   });
 
@@ -61,17 +61,17 @@ describe('SyncComponent', () => {
   it('should populate definitions from loaded configuration', () => {
     mountComponent().then(({ fixture }) => {
       fixture.detectChanges();
-      expect(fixture.componentInstance.definitions).to.deep.equal(mockDefinitions);
+      expect(fixture.componentInstance.definitions()).to.deep.equal(mockDefinitions);
     });
   });
 
   it('should add a new empty definition', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      const initialLength = component.definitions.length;
+      const initialLength = component.definitions().length;
       component.addDefinition();
-      expect(component.definitions).to.have.length(initialLength + 1);
-      expect(component.definitions[initialLength].sourceDirectory).to.equal('');
+      expect(component.definitions()).to.have.length(initialLength + 1);
+      expect(component.definitions()[initialLength].sourceDirectory).to.equal('');
     });
   });
 
@@ -95,9 +95,9 @@ describe('SyncComponent', () => {
   it('should create a new array reference when a definition is added', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      const originalRef = component.definitions;
+      const originalRef = component.definitions();
       component.addDefinition();
-      expect(component.definitions).to.not.equal(originalRef);
+      expect(component.definitions()).to.not.equal(originalRef);
     });
   });
 
@@ -105,7 +105,7 @@ describe('SyncComponent', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
       component.removeDefinition(0);
-      expect(component.definitions).to.have.length(0);
+      expect(component.definitions()).to.have.length(0);
     });
   });
 
@@ -121,77 +121,77 @@ describe('SyncComponent', () => {
   it('should create a new array reference when a definition is removed', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      const originalRef = component.definitions;
+      const originalRef = component.definitions();
       component.removeDefinition(0);
-      expect(component.definitions).to.not.equal(originalRef);
+      expect(component.definitions()).to.not.equal(originalRef);
     });
   });
 
   it('should move a definition up', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.definitions = [
+      component.definitions.set([
         { ...mockDefinitions[0], order: 0 },
         { sourceDirectory: '/b', destinationDirectory: '/c', includeSubFolders: false, deleteAssetsNotInSource: false, order: 1 },
-      ];
+      ]);
       component.moveUp(1);
-      expect(component.definitions[0].sourceDirectory).to.equal('/b');
+      expect(component.definitions()[0].sourceDirectory).to.equal('/b');
     });
   });
 
   it('should create a new array reference when a definition is moved up', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.definitions = [
+      component.definitions.set([
         { ...mockDefinitions[0], order: 0 },
         { sourceDirectory: '/b', destinationDirectory: '/c', includeSubFolders: false, deleteAssetsNotInSource: false, order: 1 },
-      ];
-      const originalRef = component.definitions;
+      ]);
+      const originalRef = component.definitions();
       component.moveUp(1);
-      expect(component.definitions).to.not.equal(originalRef);
+      expect(component.definitions()).to.not.equal(originalRef);
     });
   });
 
   it('should not move a definition up when already at the top', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      const first = component.definitions[0];
+      const first = component.definitions()[0];
       component.moveUp(0);
-      expect(component.definitions[0]).to.equal(first);
+      expect(component.definitions()[0]).to.equal(first);
     });
   });
 
   it('should move a definition down', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.definitions = [
+      component.definitions.set([
         { ...mockDefinitions[0], order: 0 },
         { sourceDirectory: '/b', destinationDirectory: '/c', includeSubFolders: false, deleteAssetsNotInSource: false, order: 1 },
-      ];
+      ]);
       component.moveDown(0);
-      expect(component.definitions[0].sourceDirectory).to.equal('/b');
+      expect(component.definitions()[0].sourceDirectory).to.equal('/b');
     });
   });
 
   it('should create a new array reference when a definition is moved down', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.definitions = [
+      component.definitions.set([
         { ...mockDefinitions[0], order: 0 },
         { sourceDirectory: '/b', destinationDirectory: '/c', includeSubFolders: false, deleteAssetsNotInSource: false, order: 1 },
-      ];
-      const originalRef = component.definitions;
+      ]);
+      const originalRef = component.definitions();
       component.moveDown(0);
-      expect(component.definitions).to.not.equal(originalRef);
+      expect(component.definitions()).to.not.equal(originalRef);
     });
   });
 
   it('should not move a definition down when already at the bottom', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      const last = component.definitions[component.definitions.length - 1];
-      component.moveDown(component.definitions.length - 1);
-      expect(component.definitions[component.definitions.length - 1]).to.equal(last);
+      const last = component.definitions()[component.definitions().length - 1];
+      component.moveDown(component.definitions().length - 1);
+      expect(component.definitions()[component.definitions().length - 1]).to.equal(last);
     });
   });
 
@@ -203,7 +203,7 @@ describe('SyncComponent', () => {
     mountComponent({ run, setConfiguration }).then(({ fixture }) => {
       fixture.componentInstance.saveAndRun();
       fixture.detectChanges();
-      expect(fixture.componentInstance.step).to.equal('running');
+      expect(fixture.componentInstance.step()).to.equal('running');
     });
   });
 
@@ -221,8 +221,8 @@ describe('SyncComponent', () => {
         mockSource.emitRaw('results', JSON.stringify(mockResults));
         fixture.detectChanges();
 
-        expect(fixture.componentInstance.step).to.equal('results');
-        expect(fixture.componentInstance.results).to.deep.equal(mockResults);
+        expect(fixture.componentInstance.step()).to.equal('results');
+        expect(fixture.componentInstance.results()).to.deep.equal(mockResults);
       });
   });
 
@@ -238,16 +238,16 @@ describe('SyncComponent', () => {
         mockSource.emitRaw('status', 'Processing file 2');
         fixture.detectChanges();
 
-        expect(fixture.componentInstance.statusMessages).to.deep.equal(['Processing file 1', 'Processing file 2']);
+        expect(fixture.componentInstance.statusMessages()).to.deep.equal(['Processing file 1', 'Processing file 2']);
       });
   });
 
   it('should return to configure step when backToConfigure is called', () => {
     mountComponent().then(({ fixture }) => {
       const component = fixture.componentInstance;
-      component.step = 'results';
+      component.step.set('results');
       component.backToConfigure();
-      expect(component.step).to.equal('configure');
+      expect(component.step()).to.equal('configure');
     });
   });
 

--- a/JPPhotoManagerWeb/frontend/src/app/features/sync/sync.component.html
+++ b/JPPhotoManagerWeb/frontend/src/app/features/sync/sync.component.html
@@ -1,10 +1,10 @@
 <div class="sync-container p-16">
   <h2>Sync Assets</h2>
 
-  @if (step === 'configure') {
+  @if (step() === 'configure') {
     <mat-card>
       <mat-card-content>
-        <table mat-table [dataSource]="definitions" class="full-width">
+        <table mat-table [dataSource]="definitions()" class="full-width">
           <ng-container matColumnDef="sourceDirectory">
             <th mat-header-cell *matHeaderCellDef>Source Directory</th>
             <td mat-cell *matCellDef="let def">
@@ -41,7 +41,7 @@
             <th mat-header-cell *matHeaderCellDef>Actions</th>
             <td mat-cell *matCellDef="let def; let i = index">
               <button mat-icon-button (click)="moveUp(i)" [disabled]="i === 0"><mat-icon>arrow_upward</mat-icon></button>
-              <button mat-icon-button (click)="moveDown(i)" [disabled]="i === definitions.length - 1"><mat-icon>arrow_downward</mat-icon></button>
+              <button mat-icon-button (click)="moveDown(i)" [disabled]="i === definitions().length - 1"><mat-icon>arrow_downward</mat-icon></button>
               <button mat-icon-button color="warn" (click)="removeDefinition(i)"><mat-icon>delete</mat-icon></button>
             </td>
           </ng-container>
@@ -53,20 +53,20 @@
 
       <mat-card-actions>
         <button mat-button (click)="addDefinition()"><mat-icon>add</mat-icon> Add</button>
-        <button mat-raised-button color="primary" (click)="saveAndRun()" [disabled]="definitions.length === 0 || !authService.isAdmin()">
+        <button mat-raised-button color="primary" (click)="saveAndRun()" [disabled]="definitions().length === 0 || !authService.isAdmin()">
           <mat-icon>play_arrow</mat-icon> Save & Run
         </button>
       </mat-card-actions>
     </mat-card>
   }
 
-  @if (step === 'running') {
+  @if (step() === 'running') {
     <mat-card>
       <mat-card-content>
         <mat-progress-bar mode="indeterminate" />
         <p>Syncing in progress...</p>
         <mat-list>
-          @for (msg of statusMessages; track $index) {
+          @for (msg of statusMessages(); track $index) {
             <mat-list-item>{{ msg }}</mat-list-item>
           }
         </mat-list>
@@ -74,11 +74,11 @@
     </mat-card>
   }
 
-  @if (step === 'results') {
+  @if (step() === 'results') {
     <mat-card>
       <mat-card-header><mat-card-title>Results</mat-card-title></mat-card-header>
       <mat-card-content>
-        @for (result of results; track $index) {
+        @for (result of results(); track $index) {
           <div class="result-item" [class.result-error]="!result.success">
             <strong>{{ result.sourceDirectory }} → {{ result.destinationDirectory }}</strong>
             <span>Copied: {{ result.syncedCount }}, Deleted: {{ result.deletedCount }}</span>

--- a/JPPhotoManagerWeb/frontend/src/app/features/sync/sync.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/features/sync/sync.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnDestroy, OnInit, ChangeDetectionStrategy, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatTableModule } from '@angular/material/table';
 import { MatButtonModule } from '@angular/material/button';
@@ -30,16 +30,16 @@ type ProcessStep = 'configure' | 'running' | 'results';
     MatListModule
   ],
   templateUrl: './sync.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './sync.component.scss'
 })
 export class SyncComponent implements OnInit, OnDestroy {
 
-  step: ProcessStep = 'configure';
-  definitions: SyncAssetsDirectoriesDefinition[] = [];
-  statusMessages: string[] = [];
-  results: SyncAssetsResult[] = [];
-  running = false;
+  readonly step = signal<ProcessStep>('configure');
+  readonly definitions = signal<SyncAssetsDirectoriesDefinition[]>([]);
+  readonly statusMessages = signal<string[]>([]);
+  readonly results = signal<SyncAssetsResult[]>([]);
+  readonly running = signal(false);
 
   private eventSource?: EventSource;
 
@@ -53,7 +53,7 @@ export class SyncComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.syncService.getConfiguration().subscribe({
-      next: defs => this.definitions = defs,
+      next: defs => this.definitions.set(defs),
       error: () => this.snackBar.open('Failed to load configuration', 'Dismiss', { duration: 3000 })
     });
   }
@@ -63,70 +63,73 @@ export class SyncComponent implements OnInit, OnDestroy {
   }
 
   addDefinition(): void {
-    this.definitions = [...this.definitions, {
+    this.definitions.update(defs => [...defs, {
       sourceDirectory: '',
       destinationDirectory: '',
       includeSubFolders: false,
       deleteAssetsNotInSource: false,
-      order: this.definitions.length
-    }];
+      order: defs.length
+    }]);
   }
 
   removeDefinition(index: number): void {
-    this.definitions = this.definitions.filter((_, i) => i !== index);
+    this.definitions.update(defs => defs.filter((_, i) => i !== index));
   }
 
   moveUp(index: number): void {
     if (index > 0) {
-      const updated = [...this.definitions];
-      [updated[index - 1], updated[index]] = [updated[index], updated[index - 1]];
-      this.definitions = updated;
+      this.definitions.update(defs => {
+        const updated = [...defs];
+        [updated[index - 1], updated[index]] = [updated[index], updated[index - 1]];
+        return updated;
+      });
     }
   }
 
   moveDown(index: number): void {
-    if (index < this.definitions.length - 1) {
-      const updated = [...this.definitions];
+    this.definitions.update(defs => {
+      if (index >= defs.length - 1) return defs;
+      const updated = [...defs];
       [updated[index], updated[index + 1]] = [updated[index + 1], updated[index]];
-      this.definitions = updated;
-    }
+      return updated;
+    });
   }
 
   saveAndRun(): void {
-    this.syncService.setConfiguration(this.definitions).subscribe({
+    this.syncService.setConfiguration(this.definitions()).subscribe({
       next: () => this.runSync(),
       error: () => this.snackBar.open('Failed to save configuration', 'Dismiss', { duration: 3000 })
     });
   }
 
   private runSync(): void {
-    this.step = 'running';
-    this.running = true;
-    this.statusMessages = [];
-    this.results = [];
+    this.step.set('running');
+    this.running.set(true);
+    this.statusMessages.set([]);
+    this.results.set([]);
 
     const eventSource = this.syncService.run();
     this.eventSource = eventSource;
 
     eventSource.addEventListener('status', (event: MessageEvent) => {
-      this.statusMessages.push(event.data);
+      this.statusMessages.update(msgs => [...msgs, event.data]);
     });
 
     eventSource.addEventListener('results', (event: MessageEvent) => {
-      this.results = JSON.parse(event.data as string) as SyncAssetsResult[];
-      this.step = 'results';
-      this.running = false;
+      this.results.set(JSON.parse(event.data as string) as SyncAssetsResult[]);
+      this.step.set('results');
+      this.running.set(false);
       eventSource.close();
     });
 
     eventSource.addEventListener('error', () => {
-      this.running = false;
-      this.step = 'results';
+      this.running.set(false);
+      this.step.set('results');
       eventSource.close();
     });
   }
 
   backToConfigure(): void {
-    this.step = 'configure';
+    this.step.set('configure');
   }
 }

--- a/JPPhotoManagerWeb/frontend/src/app/shared/components/about-dialog/about-dialog.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/shared/components/about-dialog/about-dialog.component.ts
@@ -8,7 +8,7 @@ import { MatIconModule } from '@angular/material/icon';
   standalone: true,
   imports: [MatDialogModule, MatButtonModule, MatIconModule],
   templateUrl: './about-dialog.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './about-dialog.component.scss',
 })
 export class AboutDialogComponent {

--- a/JPPhotoManagerWeb/frontend/src/app/shared/components/accent-color-picker/accent-color-picker.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/shared/components/accent-color-picker/accent-color-picker.component.ts
@@ -6,7 +6,7 @@ import { MatIconModule } from '@angular/material/icon';
   standalone: true,
   imports: [MatIconModule],
   templateUrl: './accent-color-picker.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './accent-color-picker.component.scss',
 })
 export class AccentColorPickerComponent {

--- a/JPPhotoManagerWeb/frontend/src/app/shared/components/catalog-progress-footer/catalog-progress-footer.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/shared/components/catalog-progress-footer/catalog-progress-footer.component.ts
@@ -11,7 +11,7 @@ import { CatalogState } from '../../../core/models/catalog-notification.model';
   standalone: true,
   imports: [DatePipe, MatIconModule, MatButtonModule, MatProgressBarModule, MatTooltipModule],
   templateUrl: './catalog-progress-footer.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './catalog-progress-footer.component.scss',
 })
 export class CatalogProgressFooterComponent {

--- a/JPPhotoManagerWeb/frontend/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
@@ -7,7 +7,7 @@ import { ConfirmDialogData } from '../../../core/models/dialog.model';
   selector: 'app-confirm-dialog',
   standalone: true,
   imports: [MatDialogModule, MatButtonModule],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <h2 mat-dialog-title>{{ data.title }}</h2>
     <mat-dialog-content>{{ data.message }}</mat-dialog-content>

--- a/JPPhotoManagerWeb/frontend/src/app/shared/components/media-fullscreen-overlay/media-fullscreen-overlay.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/shared/components/media-fullscreen-overlay/media-fullscreen-overlay.component.ts
@@ -8,7 +8,7 @@ import { Asset } from '../../../core/models/asset.model';
   standalone: true,
   imports: [MatButtonModule, MatIconModule],
   templateUrl: './media-fullscreen-overlay.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './media-fullscreen-overlay.component.scss',
 })
 export class MediaFullscreenOverlayComponent {

--- a/JPPhotoManagerWeb/frontend/src/app/shared/components/password-strength/password-strength.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/shared/components/password-strength/password-strength.component.ts
@@ -18,7 +18,7 @@ interface PasswordRule {
   standalone: true,
   imports: [MatIconModule],
   templateUrl: './password-strength.component.html',
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styleUrl: './password-strength.component.scss',
 })
 export class PasswordStrengthComponent {

--- a/JPPhotoManagerWeb/frontend/src/app/shared/components/thumbnail/thumbnail.component.ts
+++ b/JPPhotoManagerWeb/frontend/src/app/shared/components/thumbnail/thumbnail.component.ts
@@ -30,7 +30,7 @@ import { FileSizePipe } from '../../pipes/file-size.pipe';
       </mat-card-content>
     </mat-card>
   `,
-  changeDetection: ChangeDetectionStrategy.Eager,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [`
     .thumbnail-card {
       cursor: pointer;


### PR DESCRIPTION
## Summary

- Replaces `provideZoneChangeDetection` with `provideZonelessChangeDetection` in `app.config.ts`; drops `zone.js` from `angular.json`'s polyfills and from `package.json` entirely.
- Converts all 33 components from the default change-detection strategy to `OnPush`, and migrates state populated from outside Angular's own event dispatch (HTTP subscribes, SSE handlers, timers, `IntersectionObserver`, `MatDialogRef.afterClosed()`) to `signal()`, so change detection is correctly notified without zone.js's global patching.
- Updates `cypress/support/component.ts` to drop the `provideZoneChangeDetection` override that was forced into every `cy.mount()` call — Angular 22's `TestBed` is zoneless by default, so the override existed only to paper over the zone/zoneless mismatch this change removes at the source.

**Base branch note**: this targets `e2e-migration-to-cypress`, not `develop`, since the zoneless work depends on that branch's Angular 22 upgrade and Cypress Component Testing setup, neither of which is on `develop` yet.

## Changes

- **Runtime config**: `app.config.ts`, `angular.json`, `package.json` (zone.js removed).
- **Components (33)**: every component flipped to `OnPush`; async-populated fields converted to `signal()` — largest touch points are `gallery.component.ts` (~20 signals: assets/pagination/timeline/slideshow/SSE-driven fields) and `app.component.ts` (catalog SSE progress).
- **Bug fixes surfaced by the migration**:
  - `rateAsset()` was mutating an object inside the `assets` array in place — now does an immutable update via `.update()`.
  - `drop-zone.component.ts`'s `uploadQueue` needed an explicit re-set after in-place item mutation, since signals use `Object.is` equality and won't notify on a same-reference `.set()`.
  - `exif-panel.component.ts`'s `asset.tags` rollback (on a failed tag add/remove) mutates a parent-owned `@Input()` object from an async HTTP error callback — added `ChangeDetectorRef.markForCheck()` there since it can't become a signal.
  - `home.component.ts`'s stats subscribe had no `error` handler, so RxJS threw it as an uncaught exception — previously masked by zone.js's scheduling delaying it past the E2E test window, now surfaced and fixed.
- **Test infrastructure**: `cypress/support/component.ts`, plus ~80 direct field-mutations updated to the signal API (`.set()`/`.update()`) across the `gallery`/`sync`/`convert`/`duplicates`/`album-detail`/`drop-zone` Cypress component specs. Two `drop-zone` specs rewritten to dispatch real DOM `dragover`/`dragleave` events instead of calling `@HostListener` methods directly, which bypasses Angular's own change-detection notification.

## Test plan

- [x] `npm run build:prod` — production build succeeds within budget
- [x] `npm test` — all 375 Cypress component tests pass
- [x] `npm run test:e2e:mocked` — all 23 mocked E2E tests pass
- [x] `npm run test:e2e` — all 12 real-backend E2E tests pass (run against a fresh k8s deployment built from this branch via `scripts/build-and-deploy-k8s.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)