### PR TITLE
Release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v2.4.0 — 2026-08-15
+
+### Added
+- Session management: view and revoke active user sessions
+- Password strength policy enforced on user creation and admin password changes
+- Request correlation ID and MDC logging on every backend request/log line
+- Real-backend E2E suite (Cypress, against a full local k8s deployment) alongside the existing mocked tier
+- Full quality-metrics reporting suite for both frontend and backend: accessibility audit (axe-core), mutation testing, secrets scanning, license compliance, dependency vulnerabilities (SCA), bundle size, dependency staleness, and E2E run/flakiness reports, plus `npm run reports:all` (frontend), `bash scripts/run-all-quality-reports.sh` (backend), and a combined top-level `scripts/run-all-quality-reports.sh` to run everything in one command
+- 80% code coverage gate and a cyclomatic-complexity gate (backend and frontend), enforced during code review
+- `gitflow` skill: `sync-feature` action, wired into `feature-development`
+- `feature-development` skill: conditional E2E verification phase
+
+### Changed
+- Frontend upgraded to Angular 22, with unit and E2E tests migrated to Cypress
+- Frontend migrated to zoneless change detection
+- The real E2E tier now runs against a local k8s redeploy instead of docker-compose
+
+### Fixed
+- Refresh-token cookie path
+- CI build hardened, keeping zone.js as a devDependency for Cypress Component Testing
+
 ## v2.3.0 — 2026-07-22
 
 ### Added


### PR DESCRIPTION
## Summary
- Session management: view and revoke active user sessions
- Password strength policy enforced on user creation and admin password changes
- Request correlation ID and MDC logging on every backend request/log line
- Frontend upgraded to Angular 22, unit and E2E tests migrated to Cypress, and frontend switched to zoneless change detection
- New real-backend E2E suite (against a full local k8s deployment) alongside the existing mocked tier, plus a full quality-metrics reporting suite (accessibility, mutation testing, secrets scanning, license compliance, SCA, bundle size, dependency staleness, E2E run/flakiness) for both frontend and backend, with single-command runners (`npm run reports:all`, `bash scripts/run-all-quality-reports.sh`, and a combined top-level wrapper)
- 80% code coverage gate and a cyclomatic-complexity gate enforced during code review

## Changes
- **Backend**: session management + revoke endpoints, password strength policy, request correlation ID/MDC logging, refresh-token cookie path fix
- **Frontend**: Angular 22 upgrade, Cypress migration (component + E2E), zoneless change detection migration
- **Testing/CI**: real-backend E2E suite running against a local k8s redeploy (replacing docker-compose for this tier), CI build hardening (zone.js kept as a devDependency for Cypress Component Testing)
- **Quality tooling**: accessibility/mutation/secrets/license/SCA/bundle-size/dependency-staleness/E2E-flakiness report scripts for frontend and backend, plus `run-all-quality-reports` runners at every level (frontend, backend, and a combined top-level wrapper); 80% coverage and cyclomatic-complexity gates
- **Skills**: `gitflow` `sync-feature` action wired into `feature-development`; `feature-development` conditional E2E verification phase

## Test plan
- [x] Full real-backend E2E suite (`npm run test:e2e`): all 4 specs passing (`admin-users`, `albums`, `auth`, `profile-sessions` — the last verified in isolation after a login-rate-limit collision from back-to-back full-suite runs, a known/documented interaction, not a regression)
- [x] `bash scripts/run-all-quality-reports.sh --with-e2e-real` (combined frontend + backend) run clean
