### PR TITLE
Add quality-metrics skill, track quality-metric report history

### DIFF
--- a/.claude/skills/quality-metrics/SKILL.md
+++ b/.claude/skills/quality-metrics/SKILL.md
@@ -1,0 +1,378 @@
+---
+name: quality-metrics
+description: Runs every periodic quality-metric sweep (bash scripts/run-all-quality-reports.sh from JPPhotoManagerWeb/ — the frontend's npm report scripts plus the backend's bash report scripts — covering type coverage, complexity, dead code, route coverage, auth coverage, lighthouse, accessibility, code coverage, bundle size, dependency staleness, mocked E2E run, secrets scan, license compliance, dependency vulnerabilities, plus opt-in mutation testing and real-backend E2E) and reports trends by reading every committed historical report per category under JPPhotoManagerWeb/docs/reports/<category>/ — not just the immediately preceding one — and comparing the freshly generated value against that whole series. TRIGGER when the user asks for a quality metrics report, how the quality metrics are trending, to run/refresh the quality metrics, or similar — this is the quality-metrics counterpart to bugs-status/features-status, but for the report categories in the root README's Quality Metrics table rather than the backlog files.
+license: MIT
+metadata:
+  author: Juan Pablo Drexler
+  version: "1.0"
+---
+
+Runs the full periodic quality-metric sweep and reports trends — each
+category's newly generated number against **every** committed historical
+value for that category, not just the one immediately before it. These 15
+categories are committed to git specifically so this full-history
+comparison is possible — a single previous-vs-current delta can't tell a
+steady drift apart from ordinary day-to-day noise, which is the whole
+reason the reports live in git instead of being regenerated and discarded
+locally. The per-fix audit categories (`code-review/`, `security-review/`,
+`spec-compliance/`, and any similar review-skill output that lands under
+the same `docs/reports/` tree) are out of scope for this skill — they're
+gitignored, scoped to a single change, and have no trend to compute.
+
+**Input**: optional `--full` to also run the two sweeps
+`run-all-quality-reports.sh` skips by default (mutation testing on both
+sides, real-backend E2E on the frontend side) — see step 2. No input
+required otherwise.
+
+---
+
+## Steps
+
+### 1. Read the full committed history — before running anything
+
+For each category below, find **every** existing report file matching its
+pattern under `JPPhotoManagerWeb/docs/reports/<category>/` — not just the
+latest one. A category shared by both halves of the stack (complexity,
+dead code, code coverage, dependency staleness, license compliance,
+dependency vulnerabilities, mutation) writes two independent series in
+the same folder, disambiguated by a `_frontend.md` / `_backend.md` suffix
+— track those as two separate series, never merged into one.
+
+| Category (folder under `JPPhotoManagerWeb/docs/reports/`) | Side(s) | File pattern |
+| --- | --- | --- |
+| type-coverage | frontend only | `TYPE_COVERAGE_REPORT_*.md` |
+| complexity | both | `COMPLEXITY_REPORT_*_frontend.md` / `COMPLEXITY_REPORT_*_backend.md` |
+| dead-code | both | `DEAD_CODE_REPORT_*_frontend.md` / `DEAD_CODE_REPORT_*_backend.md` |
+| route-coverage | frontend only | `ROUTE_COVERAGE_REPORT_*_frontend.md` |
+| auth-coverage | backend only | `AUTH_COVERAGE_REPORT_*_backend.md` |
+| lighthouse | frontend only | `LIGHTHOUSE_REPORT_*_frontend.md` |
+| a11y | frontend only | `A11Y_REPORT_*_frontend.md` |
+| code-coverage | both | `CODE_COVERAGE_REPORT_*_frontend.md` / `CODE_COVERAGE_REPORT_*_backend.md` |
+| bundle-size | frontend only | `BUNDLE_SIZE_REPORT_*.md` |
+| dependency-staleness | both | `DEPENDENCY_STALENESS_REPORT_*_frontend.md` / `DEPENDENCY_STALENESS_REPORT_*_backend.md` |
+| e2e-run (mocked) | frontend only | `E2E_RUN_REPORT_*_mocked.md` |
+| e2e-run (real) — only if `--full` | frontend only | `E2E_RUN_REPORT_*_real.md` |
+| mutation | both | `MUTATION_REPORT_*_frontend.md` / `MUTATION_REPORT_*_backend.md` (both only if `--full`) |
+| secrets-scan | whole repo | `SECRETS_SCAN_REPORT_*.md` |
+| license-compliance | both | `LICENSE_COMPLIANCE_REPORT_*_frontend.md` / `LICENSE_COMPLIANCE_REPORT_*_backend.md` |
+| dependency-vulnerabilities | both | `SCA_REPORT_*_frontend.md` / `SCA_REPORT_*_backend.md` |
+
+**Order every file by its embedded `**Generated:**` ISO timestamp, never
+by filename or filesystem mtime.** The filename's date fragment doesn't
+sort correctly once a same-day rerun adds a `-2`/`-3` suffix (most of
+these scripts actually overwrite a same-day file in place instead — see
+step 3 — but not all of them do, so don't rely on that either way), and
+mtime is actively unreliable here: git does not preserve original file
+modification times, so a fresh clone or a `git checkout` stamps every
+file with the checkout time, making "sort by mtime" meaningless for
+anyone who didn't generate every report in the same uninterrupted working
+copy. Every report template writes a `**Generated:** <ISO timestamp>`
+line near the top specifically because it's the one reliable ordering
+key — use it.
+
+Read each file's metrics per the extraction table in step 4 as you go, so
+each category-and-side ends this step as a chronological list of
+`(generated timestamp, extracted values)` pairs — the series' full trend
+prior to this run. If a pattern matches nothing, that category/side has
+no history yet; say so rather than fabricating a series.
+
+**Efficiency note:** don't `Read` every historical file in full. For a
+category whose headline lives on one `**Label:** value` line, one `Grep`
+call across the whole folder with a pattern alternating `\*\*Generated:\*\*`
+and the headline pattern (e.g. `\*\*Generated:\*\*|\*\*Type coverage:\*\*`)
+returns both fields, one match per line, for every file in a single pass —
+pair each file's two matches back up by its path in the Grep output. For a
+table-based category (lighthouse's/route-coverage's per-route rows,
+a11y's impact-breakdown table, auth-coverage's endpoint table), grep the
+specific row pattern instead of a bold-line pattern — see step 4 for which
+categories need this.
+
+### 2. Run the sweep
+
+Touch a marker file, then run `bash scripts/run-all-quality-reports.sh`
+from `JPPhotoManagerWeb/` (it runs both the frontend's `npm run
+reports:all` and the backend's `bash scripts/run-all-quality-reports.sh`
+in sequence) so every fresh report's mtime can be told apart from the
+history read in step 1 (mtime is fine for this — it only needs to
+distinguish "the file this run just wrote" from "everything older,"
+within one uninterrupted working copy, not to order history across a
+clone or checkout):
+
+```
+cd JPPhotoManagerWeb
+touch /tmp/quality-metrics-marker  # or the session scratchpad, same effect
+bash scripts/run-all-quality-reports.sh
+```
+
+This skips two reports by default: mutation testing on both sides (a full
+PIT/Stryker run per mutant — minutes, not seconds) and the frontend's
+real-backend E2E tier (needs the full app already deployed to k8s — see
+the `e2e-suite` skill §1 for that precondition). Budget several minutes
+for the full run (the frontend build, Lighthouse, mocked E2E, and axe-core
+are the slow steps on that side; JaCoCo/PMD/dependency-analyze runs add
+more on the backend side); use a generous Bash timeout rather than letting
+it get cut off, and prefer running it in the background and waiting for
+completion over polling a fixed number of times.
+
+If the user passed `--full` (or explicitly asked to include mutation
+and/or the real-backend E2E check), re-run with:
+
+```
+bash scripts/run-all-quality-reports.sh --with-mutation --with-e2e-real
+```
+
+A failing individual report does not stop the run — the script prints an
+`OK`/`FAILED`/`SKIP` summary for each half at the end. Note which
+categories failed; their "current" value in step 6 is really last run's
+data, not a fresh one, and the report should say so rather than silently
+treating it as current.
+
+**Don't mistake a long, noisy run for a hang.** The code-coverage and
+mutation reports drive a full test suite (Cypress component tests on the
+frontend, JUnit/PIT on the backend) and can print a great deal of
+intermediate output — build warnings, per-spec results, framework
+diagnostics — while genuinely still progressing rather than stuck. Don't
+kill a run just because the console looks busy or repetitive; confirm a
+step actually failed by checking the script's own final `OK`/`FAILED`/
+`SKIP` summary, or whether the category's report file exists, rather than
+by eyeballing console noise mid-run.
+
+### 3. Capture the fresh snapshot
+
+```
+find JPPhotoManagerWeb/docs/reports -newer /tmp/quality-metrics-marker -name '*.md'
+```
+
+This lists every newly written report file across all categories in one
+shot. Match each one back to its category (and frontend/backend side, by
+filename suffix) and extract its key metrics per the same extraction
+table in step 4, appending it as the newest point on that series from
+step 1. Most of these scripts overwrite a same-day file in place rather
+than adding a `-2`/`-3` suffix — a second same-day run of this skill will
+often show the same filename in this list as step 1's history read, just
+with a newer `**Generated:**` timestamp inside it. That's expected: the
+morning's intermediate value is simply gone from disk once overwritten
+unless it was committed in between.
+
+### 4. Extract each category's key metrics
+
+Applies to every historical file from step 1 and every fresh file from
+step 3 alike — the same fields, the same patterns per category, so each
+file becomes one point on its series. Pull these fields via `Grep`/pattern
+match — most of these report scripts write consistent bold-line phrasing,
+but the backend's Maven-CLI-wrapping scripts (`dead-code` and
+`dependency-staleness`, backend side) don't produce a clean summary line
+at all, so those two need a best-effort line-count instead:
+
+| Category / side | Fields to extract | Where in the file |
+| --- | --- | --- |
+| type-coverage | Type coverage %; untyped (`any`) count | `**Type coverage:** X%` / `**Untyped (\`any\`) identifiers:** N` |
+| complexity (frontend) | Files scanned; functions analyzed; avg complexity; avg file size | `**Files scanned:** N`; `**Functions analyzed:** N (average complexity: X...)`; `**Average file size:** N lines` |
+| complexity (backend) | Files scanned; methods analyzed; avg complexity; avg file size | same shape, `**Methods analyzed:**` instead of `**Functions analyzed:**` |
+| dead-code (frontend) | Total findings + sub-counts | `**Total findings:** N (a unused file(s), b unused export(s), c unused type(s), d unused dependenc(y/ies), e unlisted dependenc(y/ies))` |
+| dead-code (backend) | Unused/undeclared dependency counts (best-effort) | no bold summary — this is raw `mvn dependency:analyze` output; count lines under the "Unused declared dependencies" and "Used undeclared dependencies" sections, and note that every `spring-boot-starter-*` entry is documented as expected noise, not a real finding — don't count those toward a "regression" |
+| route-coverage | Routes-with-no-E2E-coverage count | `**Routes with no E2E coverage in either tier:** ...` (count the comma-separated list, or "none") |
+| auth-coverage | Total endpoints tracked; count resolving to `permitAll()` | no bold summary — this is a raw endpoint table; count table rows (`^\| [A-Z]+ \|`) for the total, and count rows containing `permitAll()` in the Governing rule column for the second figure |
+| lighthouse | Performance/Accessibility/Best Practices/SEO per route | the results table |
+| a11y | Total violations; Critical/Serious/Moderate/Minor breakdown | `**Total violations:** N`; the impact-count table |
+| code-coverage (frontend) | Statements/Branches/Functions/Lines %; files-below-80% count | `**Statements:** X% (a/b)` (same shape for the other 3); `## N file(s) below 80% on at least one metric` |
+| code-coverage (backend) | Lines/Branches/Methods % (JaCoCo) | `**Lines:** X% (a/b)` (same shape for `**Branches:**`/`**Methods:**`) |
+| bundle-size | Initial bundle size (kB); budget status; total JS shipped (kB); total dist size (kB) | the four `**...:**` lines near the top |
+| dependency-staleness (frontend) | Total direct deps; outdated count + major/minor/patch breakdown | `**Total dependencies (direct):** N`; `**Outdated:** N (a major, b minor, c patch behind)` |
+| dependency-staleness (backend) | Outdated dependency count (best-effort) | no bold summary — this is raw `mvn versions:display-dependency-updates` output; count `[INFO]   <groupId>:<artifactId> ... -> ...` lines |
+| e2e-run (mocked/real) | Tests total/passed/failed/skipped; flaky count; total duration | `**Tests:** N (p passed, f failed, s skipped)`; `**Flaky tests...:** N`; `**Total duration:** Xs` |
+| mutation (frontend) | Overall mutation score %; killed/total mutants | `**Overall mutation score:** X% (k/t tested mutants killed)` |
+| mutation (backend) | Line coverage %; mutation coverage %; test strength % (PIT) | `**Line coverage:** X%`; `**Mutation coverage:** X%`; `**Test strength:** X%` |
+| secrets-scan | Findings count | `**Findings:** N potential secret(s)` |
+| license-compliance (frontend) | Packages scanned; flagged count | `**N package(s) scanned, M flagged**` |
+| license-compliance (backend) | Packages scanned; needing action; previously-accepted count | `**N package(s) scanned, M need action, K previously reviewed and accepted.**` |
+| dependency-vulnerabilities (frontend) | Vulnerable package count; critical/high/moderate/low/info breakdown | `**N vulnerable package(s):** c critical, h high, m moderate, l low, i info` |
+| dependency-vulnerabilities (backend) | Known-vulnerability count (OSV.dev) | `**N known vulnerabilities across the resolved dependency tree.**` |
+
+### 5. Describe the trend across the full series
+
+Each category-and-side now has a chronological list of values (every
+historical report plus the fresh one). Don't collapse this to a single
+previous-vs-current delta — that's exactly the "can't tell a steady drift
+from noise" problem committing the history was meant to fix. For each
+metric:
+
+- **State the most-recent delta** (fresh value vs. the point immediately
+  before it) — still the single most actionable number, and the one that
+  answers "did today's run change anything."
+- **Characterize the shape of the whole series** in one short phrase,
+  judged across every point, not just the last two:
+  - **Flat** — values cluster tightly with no consistent direction (the
+    normal case for a healthy, stable metric).
+  - **Steadily improving / steadily declining** — most consecutive points
+    move the same direction, or the latest point continues a run of
+    several same-direction moves.
+  - **Volatile** — swings both directions across the series with no
+    consistent pattern; a single-point delta here would be misleading
+    either way.
+  - **One-off** — the series was flat/stable and the fresh point is a
+    single outlier that breaks the pattern for the first time — worth
+    flagging even though it's only one data point, precisely *because*
+    the history shows it's a break from an established baseline rather
+    than ordinary noise.
+  - **First data point** / **too little history** — fewer than 3 points
+    total (including the fresh one). Say so plainly rather than
+    describing a "shape" from 1–2 points; a shape claim needs at least 3
+    to distinguish a real pattern from a single delta.
+- **Judge direction** using the same good-thing/bad-thing classification:
+  - **Higher is better:** type coverage %, coverage % (all sides/metrics),
+    lighthouse scores, mutation/line/test-strength %, license packages
+    scanned (informational, not good/bad), E2E tests passed.
+  - **Lower is better (ideally 0):** untyped count, dead-code findings,
+    route-coverage gaps, auth-coverage endpoints with no explicit rule (if
+    tracked that way — judge case by case, since `permitAll()` on a
+    genuinely public endpoint like login isn't a defect), a11y violations,
+    files-below-80%-coverage count, dependency-staleness outdated counts,
+    E2E failed/flaky count, secrets findings, license flagged/needs-action
+    count, vulnerability counts (overall and per severity), average
+    complexity.
+  - **Informational only (track, don't judge):** files/functions/methods
+    scanned, average file size, bundle size in kB vs. its budget (flag
+    only if it crosses from "within budget" to "over budget" or vice
+    versa), test duration, total dependency count, total endpoints
+    tracked (a growing API surface isn't itself good or bad).
+
+Use ▲ for improved, ▼ for regressed, → for flat/unchanged, and — for "not
+enough history yet."
+
+### 6. Display the trend report
+
+One table per category group, headline metric(s) with a compact
+**History** column (every value in the series, oldest→newest) plus the
+most-recent delta, the shape description from step 5, and a trend marker;
+secondary/breakdown numbers folded into a Notes column rather than their
+own row (keeps this scannable across roughly 20 category/side series):
+
+```
+## Quality Metrics Trend Report — <today's date>
+
+**Sweep:** bash scripts/run-all-quality-reports.sh[ --with-mutation --with-e2e-real] (commit <short hash>)
+[If any category failed to refresh:] **Note:** <category> (<side>) failed this run — showing its last available snapshot, not a fresh one.
+
+### Coverage & correctness
+
+| Category | Headline | History (oldest→newest) | Latest Δ | Shape | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Component coverage (frontend) | Branches | … | … | … | Lines/Fn/Stmt moved similarly; N files below 80% |
+| Backend coverage (JaCoCo) | Lines | … | … | … | Branches/Methods moved similarly |
+| Type coverage | Type coverage | … | … | … | Untyped count |
+| Mutation (frontend) [only if run] | Score | … | … | … | k/t mutants killed |
+| Mutation (backend, PIT) [only if run] | Mutation coverage | … | … | … | Line coverage / test strength |
+| E2E (mocked) | Passed/Failed | … | … | … | Flaky count, duration |
+| E2E (real) [only if run] | Passed/Failed | … | … | … | … |
+
+### Code health
+
+| Category | Headline | History (oldest→newest) | Latest Δ | Shape | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Complexity (frontend) | Avg complexity | … | … | … | files scanned, avg size |
+| Complexity (backend) | Avg complexity | … | … | … | files scanned, avg size |
+| Dead code (frontend) | Total findings | … | … | … | breakdown |
+| Dead code (backend) | Unused/undeclared dep lines | … | … | … | spring-boot-starter-* noise excluded |
+| Bundle size | Initial bundle | … | … | … | budget status, total JS/dist |
+
+### Security & dependencies
+
+| Category | Headline | History (oldest→newest) | Latest Δ | Shape | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Dependency vulnerabilities (frontend) | Vulnerable packages | … | … | … | severity breakdown |
+| Dependency vulnerabilities (backend, OSV) | Known vulnerabilities | … | … | … | |
+| Dependency staleness (frontend) | Outdated | … | … | … | major/minor/patch |
+| Dependency staleness (backend) | Outdated (Maven) | … | … | … | |
+| Secrets scan | Findings | … | … | … | |
+| License compliance (frontend) | Flagged | … | … | … | |
+| License compliance (backend) | Needs action | … | … | … | previously-accepted count |
+| Route coverage | Uncovered routes | … | … | … | which routes |
+| Auth coverage | Endpoints tracked | … | … | … | count on permitAll() |
+
+### Accessibility & performance
+
+| Category | Headline | History (oldest→newest) | Latest Δ | Shape | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Lighthouse | Performance (per route) | … | … | … | Accessibility/Best Practices/SEO |
+| Accessibility audit (a11y) | Total violations | … | … | … | impact breakdown |
+
+### ⚠ Regressions
+
+[List every metric that moved the wrong direction, most severe first — weight a "one-off" break from a flat series higher than a move within an already-volatile one. "None." if clean.]
+
+### First-time / too little history
+
+[List any category/side with fewer than 3 points total — say what IS known (the values that exist) without claiming a shape.]
+```
+
+### 7. Note next steps — never auto-commit
+
+The freshly generated files are new uncommitted changes under the tracked
+`JPPhotoManagerWeb/docs/reports/<category>/` folders. Point this out and
+suggest committing them (so the trend history in git actually grows), but
+per this project's standing convention (`CLAUDE.md`, and every other
+skill here), **never commit without being asked** — end the turn with the
+trend report and let the user decide.
+
+---
+
+## Guardrails
+
+- **Report only — never fix.** If a regression shows up (a new
+  vulnerability, a coverage drop, a bundle-budget breach, an endpoint that
+  quietly lost its explicit auth rule), report it; don't start editing
+  source, tests, `SecurityConfig`, or the bug backlog in response. That's
+  a separate, explicit follow-up (`bug-report`/`bug-fix` for a real
+  defect, `dependency-upgrade` for stale/vulnerable packages).
+- **Never fabricate a delta or a shape.** If a category/side has no
+  history yet, say so plainly instead of inventing a "previous" value. If
+  it has fewer than 3 points, report the values that exist but don't
+  claim a "flat"/"volatile"/"steadily improving" shape from 1–2 points —
+  that's a delta claim wearing a trend-shape costume.
+- **Always read the full committed history, not just the latest file.**
+  Comparing only the immediately preceding value defeats the entire point
+  of committing these reports — it can't distinguish a steady multi-run
+  drift from ordinary noise. Every category lookup in step 1 must glob
+  every matching file, not just the newest.
+- **Order history by the embedded `**Generated:**` timestamp, never by
+  filename or filesystem mtime.** Filenames don't sort correctly once a
+  same-day rerun adds a `-2`/`-3` suffix (and most of these scripts don't
+  even do that — they overwrite in place), and git does not preserve
+  original mtimes — a clone or checkout stamps every file with the
+  checkout time, silently scrambling any mtime-based ordering for anyone
+  who didn't generate the whole history in one uninterrupted working copy.
+  Mtime is still the right tool for step 2–3's marker-file/`find -newer`
+  diff, since that only needs to isolate "the file this run just wrote"
+  within the current session — a different, narrower job than ordering
+  history.
+- **Two independent series share a folder for shared categories.**
+  Complexity, dead code, code coverage, dependency staleness, license
+  compliance, dependency vulnerabilities, and mutation each have a
+  `_frontend`/`_backend` pair in the same `docs/reports/<category>/`
+  directory — never merge them into one series or diff a frontend value
+  against a backend one.
+- **The backend's Maven-CLI-wrapped reports have no clean summary line.**
+  `dead-code` and `dependency-staleness` on the backend side are raw
+  `mvn dependency:analyze` / `mvn versions:display-dependency-updates`
+  output — extracting a trend number means counting matching lines, which
+  is inherently more approximate than the bold-line categories. Say so
+  in the report rather than presenting a Maven-CLI-derived count with the
+  same confidence as a clean `**Label:** value` extraction.
+- **`spring-boot-starter-*` entries in the backend dead-code report are
+  documented as expected noise, not findings** — don't count them toward
+  a regression, and don't flag their continued presence as a "flat"
+  series worth worrying about.
+- **Never treat `permitAll()` on an endpoint as inherently a problem.**
+  Auth-coverage's per-endpoint table records the governing Spring Security
+  rule as a factual snapshot, not a pass/fail gate — login/refresh-style
+  endpoints are correctly `permitAll()`. Track the count as informational
+  and flag a *change* (a previously-restricted endpoint newly resolving to
+  `permitAll()` or the `anyRequest` fallback) rather than treating the
+  bare count as good or bad on its own.
+- **Never commit the new report files.** Generate and report on them; only
+  stage/commit if the user explicitly asks, same as every other skill in
+  this repo.
+- If `scripts/run-all-quality-reports.sh` itself fails to run at all (not
+  just one sub-report), don't fabricate a trend report — surface the
+  failure and stop.

--- a/.gitignore
+++ b/.gitignore
@@ -277,5 +277,25 @@ JPPhotoManagerWeb/frontend/reports/
 JPPhotoManagerWeb/.env
 JPPhotoManagerWeb/k8s/secret.yaml
 JPPhotoManagerWeb/k8s/catalog-volumes.yaml
-# Claude Code skill review reports (local working artifacts, not committed history)
-JPPhotoManagerWeb/docs/reports/
+# Claude Code skill review reports. Per-change audit reports (code-review,
+# security-review, spec-compliance, and similar review-skill output) are
+# scoped to one fix/feature and not committed. The periodic quality-metric
+# sweeps below ARE committed so their dated files build a trend history in
+# the repo — see the root README's Quality Metrics section for what each
+# one measures.
+JPPhotoManagerWeb/docs/reports/*
+!JPPhotoManagerWeb/docs/reports/type-coverage/
+!JPPhotoManagerWeb/docs/reports/complexity/
+!JPPhotoManagerWeb/docs/reports/dead-code/
+!JPPhotoManagerWeb/docs/reports/route-coverage/
+!JPPhotoManagerWeb/docs/reports/auth-coverage/
+!JPPhotoManagerWeb/docs/reports/lighthouse/
+!JPPhotoManagerWeb/docs/reports/a11y/
+!JPPhotoManagerWeb/docs/reports/code-coverage/
+!JPPhotoManagerWeb/docs/reports/bundle-size/
+!JPPhotoManagerWeb/docs/reports/dependency-staleness/
+!JPPhotoManagerWeb/docs/reports/e2e-run/
+!JPPhotoManagerWeb/docs/reports/secrets-scan/
+!JPPhotoManagerWeb/docs/reports/license-compliance/
+!JPPhotoManagerWeb/docs/reports/dependency-vulnerabilities/
+!JPPhotoManagerWeb/docs/reports/mutation/

--- a/JPPhotoManagerWeb/README.md
+++ b/JPPhotoManagerWeb/README.md
@@ -30,7 +30,7 @@ This README is split into topic-specific files under [`docs/`](docs/):
 
 ## Quality Metrics
 
-Each report below is a dated markdown snapshot written to `JPPhotoManagerWeb/docs/reports/<category>/` (gitignored, regenerated on demand — a fresh run adds a new dated file rather than overwriting the last one, so the directory accumulates a history you can diff over time). Frontend commands run from `frontend/`; backend commands run from `backend/`. A category with both a frontend and backend version writes separate `*_frontend.md` / `*_backend.md` files under the same directory.
+Each report below is a dated markdown snapshot written to `JPPhotoManagerWeb/docs/reports/<category>/` and **committed to the repo** so the directory accumulates a real trend history over time — a fresh run adds a new dated file rather than overwriting the last one (though several report scripts overwrite a same-day file in place rather than adding a `-2` suffix — check each report's own `**Generated:**` timestamp, not its filename, to tell runs apart). Frontend commands run from `frontend/`; backend commands run from `backend/`. A category with both a frontend and backend version writes separate `*_frontend.md` / `*_backend.md` files under the same directory.
 
 | Metric | Report location | Regenerate |
 |---|---|---|

--- a/JPPhotoManagerWeb/docs/reports/a11y/A11Y_REPORT_2026-08-15_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/a11y/A11Y_REPORT_2026-08-15_frontend.md
@@ -1,0 +1,123 @@
+# Accessibility Audit Report (frontend) — 2026-08-15
+
+**Commit:** a62ecce
+**Generated:** 2026-08-15T19:44:12.978Z
+**Scope:** 11 authenticated routes (cypress-axe/axe-core, mocked session + intercepted `/api/**` calls — no live backend), the deep complement to `npm run lighthouse:report`'s Lighthouse accessibility score for `/login`: /home, /gallery, /sync, /convert, /duplicates, /admin/users, /albums, /albums/1, /recycle-bin, /analytics, /profile/sessions.
+
+**Total violations:** 50
+
+## Violations by impact
+
+| Impact | Count |
+| --- | --- |
+| critical | 5 |
+| serious | 13 |
+| moderate | 32 |
+| minor | 0 |
+
+## Violations by route
+
+### `/home` (3)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `color-contrast` | serious | 14 (.active > .mdc-button__label; a[href$="gallery"] > .mdc-button__label; a[href$="sync"] > .mdc-button__label; +11 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `region` | moderate | 24 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); .active > .mdc-button__label; a[href$="gallery"] > .mdc-button__label; +21 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |
+
+### `/gallery` (6)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `aria-treeitem-name` | serious | 1 (mat-tree-node) | Ensure every ARIA treeitem node has an accessible name | [ARIA treeitem nodes should have an accessible name](https://dequeuniversity.com/rules/axe/4.13/aria-treeitem-name?application=axeAPI) |
+| `button-name` | critical | 1 (.mat-mdc-button-disabled) | Ensure buttons have discernible text | [Buttons must have discernible text](https://dequeuniversity.com/rules/axe/4.13/button-name?application=axeAPI) |
+| `color-contrast` | serious | 12 (a[routerlink="/home"] > .mdc-button__label; a[routerlink="/sync"] > .mdc-button__label; a[routerlink="/convert"] > .mdc-button__label; +9 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `page-has-heading-one` | moderate | 1 (html) | Ensure that the page, or at least one of its frames contains a level-one heading | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.13/page-has-heading-one?application=axeAPI) |
+| `region` | moderate | 28 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; +25 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |
+
+### `/sync` (6)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `button-name` | critical | 3 (.mat-mdc-button-disabled.mdc-icon-button[mat-ripple-loader-disabled=""]:nth-child(1); .mat-mdc-button-disabled.mdc-icon-button[mat-ripple-loader-disabled=""]:nth-child(2); .mat-warn) | Ensure buttons have discernible text | [Buttons must have discernible text](https://dequeuniversity.com/rules/axe/4.13/button-name?application=axeAPI) |
+| `color-contrast` | serious | 11 (a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; .active > .mdc-button__label; +8 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `label` | critical | 2 (#mat-mdc-checkbox-0-input; #mat-mdc-checkbox-1-input) | Ensure every form element has a label | [Form elements must have labels](https://dequeuniversity.com/rules/axe/4.13/label?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `page-has-heading-one` | moderate | 1 (html) | Ensure that the page, or at least one of its frames contains a level-one heading | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.13/page-has-heading-one?application=axeAPI) |
+| `region` | moderate | 18 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; +15 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |
+
+### `/convert` (6)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `button-name` | critical | 3 (.mat-mdc-button-disabled.mdc-icon-button[mat-ripple-loader-disabled=""]:nth-child(1); .mat-mdc-button-disabled.mdc-icon-button[mat-ripple-loader-disabled=""]:nth-child(2); .mat-warn) | Ensure buttons have discernible text | [Buttons must have discernible text](https://dequeuniversity.com/rules/axe/4.13/button-name?application=axeAPI) |
+| `color-contrast` | serious | 10 (a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; a[routerlink="/sync"] > .mdc-button__label; +7 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `label` | critical | 1 (#mat-mdc-checkbox-0-input) | Ensure every form element has a label | [Form elements must have labels](https://dequeuniversity.com/rules/axe/4.13/label?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `page-has-heading-one` | moderate | 1 (html) | Ensure that the page, or at least one of its frames contains a level-one heading | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.13/page-has-heading-one?application=axeAPI) |
+| `region` | moderate | 17 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; +14 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |
+
+### `/duplicates` (4)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `color-contrast` | serious | 11 (a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; a[routerlink="/sync"] > .mdc-button__label; +8 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `page-has-heading-one` | moderate | 1 (html) | Ensure that the page, or at least one of its frames contains a level-one heading | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.13/page-has-heading-one?application=axeAPI) |
+| `region` | moderate | 18 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; +15 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |
+
+### `/admin/users` (4)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `color-contrast` | serious | 10 (a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; a[routerlink="/sync"] > .mdc-button__label; +7 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `page-has-heading-one` | moderate | 1 (html) | Ensure that the page, or at least one of its frames contains a level-one heading | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.13/page-has-heading-one?application=axeAPI) |
+| `region` | moderate | 18 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; +15 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |
+
+### `/albums` (4)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `color-contrast` | serious | 10 (a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; a[routerlink="/sync"] > .mdc-button__label; +7 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `page-has-heading-one` | moderate | 1 (html) | Ensure that the page, or at least one of its frames contains a level-one heading | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.13/page-has-heading-one?application=axeAPI) |
+| `region` | moderate | 15 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; +12 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |
+
+### `/albums/1` (4)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `color-contrast` | serious | 9 (a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; a[routerlink="/sync"] > .mdc-button__label; +6 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `page-has-heading-one` | moderate | 1 (html) | Ensure that the page, or at least one of its frames contains a level-one heading | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.13/page-has-heading-one?application=axeAPI) |
+| `region` | moderate | 14 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; +11 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |
+
+### `/recycle-bin` (4)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `color-contrast` | serious | 9 (a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; a[routerlink="/sync"] > .mdc-button__label; +6 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `page-has-heading-one` | moderate | 1 (html) | Ensure that the page, or at least one of its frames contains a level-one heading | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.13/page-has-heading-one?application=axeAPI) |
+| `region` | moderate | 14 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; +11 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |
+
+### `/analytics` (5)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `color-contrast` | serious | 9 (a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; a[routerlink="/sync"] > .mdc-button__label; +6 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `page-has-heading-one` | moderate | 1 (html) | Ensure that the page, or at least one of its frames contains a level-one heading | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.13/page-has-heading-one?application=axeAPI) |
+| `region` | moderate | 17 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; +14 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |
+| `scrollable-region-focusable` | serious | 1 (.app-content) | Ensure elements that have scrollable content are accessible by keyboard in Safari | [Scrollable region must have keyboard access](https://dequeuniversity.com/rules/axe/4.13/scrollable-region-focusable?application=axeAPI) |
+
+### `/profile/sessions` (4)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `color-contrast` | serious | 10 (a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; a[routerlink="/sync"] > .mdc-button__label; +7 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `page-has-heading-one` | moderate | 1 (html) | Ensure that the page, or at least one of its frames contains a level-one heading | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.13/page-has-heading-one?application=axeAPI) |
+| `region` | moderate | 18 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; +15 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |

--- a/JPPhotoManagerWeb/docs/reports/auth-coverage/AUTH_COVERAGE_REPORT_2026-08-14_backend.md
+++ b/JPPhotoManagerWeb/docs/reports/auth-coverage/AUTH_COVERAGE_REPORT_2026-08-14_backend.md
@@ -1,0 +1,74 @@
+# Auth Coverage Report (backend) — 2026-08-14
+
+**Commit:** 64e7da3
+**Generated:** 2026-08-14T23:27:49Z
+**Scope:** 63 endpoints across infrastructure/web/controller/*.java, resolved against SecurityConfig.java's ordered requestMatchers rules
+
+Factual snapshot of which SecurityConfig rule governs each endpoint — not a pass/fail gate. An endpoint resolving to the `anyRequest` fallback isn't automatically wrong (SecurityConfig's own fallback is `permitAll()`, and some endpoints are intentionally public), but it means no explicit `requestMatchers` rule covers it — worth a second look if that endpoint touches user data. `@PreAuthorize` (if present) is a real, separate, tighter restriction this table doesn't attempt to merge into the "Governing rule" column — read both.
+
+| Method | Path | Controller | Governing rule | @PreAuthorize |
+| --- | --- | --- | --- | --- |
+| GET | /api/admin/users | UserAdminController | hasRole("ADMIN") | - |
+| POST | /api/admin/users | UserAdminController | hasRole("ADMIN") | - |
+| DELETE | /api/admin/users/{id} | UserAdminController | hasRole("ADMIN") | - |
+| PATCH | /api/admin/users/{id}/password | UserAdminController | hasRole("ADMIN") | - |
+| GET | /api/albums | AlbumController | authenticated() | - |
+| POST | /api/albums | AlbumController | authenticated() | - |
+| DELETE | /api/albums/{id} | AlbumController | authenticated() | - |
+| GET | /api/albums/{id} | AlbumController | authenticated() | - |
+| PUT | /api/albums/{id} | AlbumController | authenticated() | - |
+| DELETE | /api/albums/{id}/assets | AlbumController | authenticated() | - |
+| POST | /api/albums/{id}/assets | AlbumController | authenticated() | - |
+| GET | /api/analytics | AnalyticsController | authenticated() | - |
+| DELETE | /api/assets | AssetController | authenticated() | hasRole('ADMIN') |
+| GET | /api/assets | AssetController | authenticated() | - |
+| GET | /api/assets/catalog | AssetController | authenticated() | hasRole('ADMIN') |
+| GET | /api/assets/catalog/observe | AssetController | authenticated() | - |
+| POST | /api/assets/download | AssetController | authenticated() | - |
+| GET | /api/assets/duplicates | AssetController | authenticated() | - |
+| POST | /api/assets/move | AssetController | authenticated() | - |
+| POST | /api/assets/rename | AssetController | authenticated() | - |
+| DELETE | /api/assets/tags/bulk | AssetController | authenticated() | - |
+| POST | /api/assets/tags/bulk | AssetController | authenticated() | - |
+| GET | /api/assets/timeline | AssetController | authenticated() | - |
+| POST | /api/assets/upload | AssetController | authenticated() | - |
+| GET | /api/assets/upload/{assetId}/observe | AssetController | authenticated() | - |
+| GET | /api/assets/{assetId}/exif | AssetController | authenticated() | - |
+| GET | /api/assets/{assetId}/image | AssetController | authenticated() | - |
+| GET | /api/assets/{assetId}/thumbnail | AssetController | authenticated() | - |
+| POST | /api/assets/{id}/crop | AssetController | authenticated() | - |
+| PATCH | /api/assets/{id}/rating | AssetController | authenticated() | - |
+| POST | /api/assets/{id}/reprocess | AssetController | authenticated() | hasRole('ADMIN') |
+| GET | /api/assets/{id}/stream | MediaController | authenticated() | - |
+| DELETE | /api/assets/{id}/tags | AssetController | authenticated() | - |
+| POST | /api/assets/{id}/tags | AssetController | authenticated() | - |
+| GET | /api/audio/playlist/{id} | MediaController | authenticated() | - |
+| GET | /api/audit-log | AuditLogController | authenticated() | - |
+| POST | /api/auth/login | AuthController | permitAll() | - |
+| POST | /api/auth/logout | AuthController | permitAll() | - |
+| GET | /api/auth/me | AuthController | authenticated() | - |
+| POST | /api/auth/refresh | AuthController | permitAll() | - |
+| DELETE | /api/auth/sessions | AuthController | authenticated() | - |
+| GET | /api/auth/sessions | AuthController | authenticated() | - |
+| DELETE | /api/auth/sessions/{id} | AuthController | authenticated() | - |
+| GET | /api/convert/configuration | ConvertController | authenticated() | - |
+| PUT | /api/convert/configuration | ConvertController | authenticated() | - |
+| GET | /api/convert/run | ConvertController | authenticated() | - |
+| GET | /api/folders | FolderController | authenticated() | - |
+| GET | /api/folders/drives | FolderController | authenticated() | - |
+| GET | /api/folders/initial | FolderController | authenticated() | - |
+| GET | /api/folders/recent-paths | FolderController | authenticated() | - |
+| GET | /api/home/stats | HomeController | authenticated() | - |
+| GET | /api/preferences | UserPreferenceController | authenticated() | - |
+| PUT | /api/preferences | UserPreferenceController | authenticated() | - |
+| DELETE | /api/recycle-bin | RecycleBinController | authenticated() | - |
+| GET | /api/recycle-bin | RecycleBinController | authenticated() | - |
+| POST | /api/recycle-bin/restore | RecycleBinController | authenticated() | - |
+| GET | /api/search-presets | SearchPresetController | authenticated() | - |
+| POST | /api/search-presets | SearchPresetController | authenticated() | - |
+| DELETE | /api/search-presets/{id} | SearchPresetController | authenticated() | - |
+| GET | /api/sync/configuration | SyncController | authenticated() | - |
+| PUT | /api/sync/configuration | SyncController | authenticated() | - |
+| GET | /api/sync/run | SyncController | authenticated() | - |
+| GET | /api/tags | TagController | authenticated() | - |
+

--- a/JPPhotoManagerWeb/docs/reports/auth-coverage/AUTH_COVERAGE_REPORT_2026-08-15_backend.md
+++ b/JPPhotoManagerWeb/docs/reports/auth-coverage/AUTH_COVERAGE_REPORT_2026-08-15_backend.md
@@ -1,0 +1,74 @@
+# Auth Coverage Report (backend) — 2026-08-15
+
+**Commit:** a62ecce
+**Generated:** 2026-08-15T20:29:16Z
+**Scope:** 63 endpoints across infrastructure/web/controller/*.java, resolved against SecurityConfig.java's ordered requestMatchers rules
+
+Factual snapshot of which SecurityConfig rule governs each endpoint — not a pass/fail gate. An endpoint resolving to the `anyRequest` fallback isn't automatically wrong (SecurityConfig's own fallback is `permitAll()`, and some endpoints are intentionally public), but it means no explicit `requestMatchers` rule covers it — worth a second look if that endpoint touches user data. `@PreAuthorize` (if present) is a real, separate, tighter restriction this table doesn't attempt to merge into the "Governing rule" column — read both.
+
+| Method | Path | Controller | Governing rule | @PreAuthorize |
+| --- | --- | --- | --- | --- |
+| GET | /api/admin/users | UserAdminController | hasRole("ADMIN") | - |
+| POST | /api/admin/users | UserAdminController | hasRole("ADMIN") | - |
+| DELETE | /api/admin/users/{id} | UserAdminController | hasRole("ADMIN") | - |
+| PATCH | /api/admin/users/{id}/password | UserAdminController | hasRole("ADMIN") | - |
+| GET | /api/albums | AlbumController | authenticated() | - |
+| POST | /api/albums | AlbumController | authenticated() | - |
+| DELETE | /api/albums/{id} | AlbumController | authenticated() | - |
+| GET | /api/albums/{id} | AlbumController | authenticated() | - |
+| PUT | /api/albums/{id} | AlbumController | authenticated() | - |
+| DELETE | /api/albums/{id}/assets | AlbumController | authenticated() | - |
+| POST | /api/albums/{id}/assets | AlbumController | authenticated() | - |
+| GET | /api/analytics | AnalyticsController | authenticated() | - |
+| DELETE | /api/assets | AssetController | authenticated() | hasRole('ADMIN') |
+| GET | /api/assets | AssetController | authenticated() | - |
+| GET | /api/assets/catalog | AssetController | authenticated() | hasRole('ADMIN') |
+| GET | /api/assets/catalog/observe | AssetController | authenticated() | - |
+| POST | /api/assets/download | AssetController | authenticated() | - |
+| GET | /api/assets/duplicates | AssetController | authenticated() | - |
+| POST | /api/assets/move | AssetController | authenticated() | - |
+| POST | /api/assets/rename | AssetController | authenticated() | - |
+| DELETE | /api/assets/tags/bulk | AssetController | authenticated() | - |
+| POST | /api/assets/tags/bulk | AssetController | authenticated() | - |
+| GET | /api/assets/timeline | AssetController | authenticated() | - |
+| POST | /api/assets/upload | AssetController | authenticated() | - |
+| GET | /api/assets/upload/{assetId}/observe | AssetController | authenticated() | - |
+| GET | /api/assets/{assetId}/exif | AssetController | authenticated() | - |
+| GET | /api/assets/{assetId}/image | AssetController | authenticated() | - |
+| GET | /api/assets/{assetId}/thumbnail | AssetController | authenticated() | - |
+| POST | /api/assets/{id}/crop | AssetController | authenticated() | - |
+| PATCH | /api/assets/{id}/rating | AssetController | authenticated() | - |
+| POST | /api/assets/{id}/reprocess | AssetController | authenticated() | hasRole('ADMIN') |
+| GET | /api/assets/{id}/stream | MediaController | authenticated() | - |
+| DELETE | /api/assets/{id}/tags | AssetController | authenticated() | - |
+| POST | /api/assets/{id}/tags | AssetController | authenticated() | - |
+| GET | /api/audio/playlist/{id} | MediaController | authenticated() | - |
+| GET | /api/audit-log | AuditLogController | authenticated() | - |
+| POST | /api/auth/login | AuthController | permitAll() | - |
+| POST | /api/auth/logout | AuthController | permitAll() | - |
+| GET | /api/auth/me | AuthController | authenticated() | - |
+| POST | /api/auth/refresh | AuthController | permitAll() | - |
+| DELETE | /api/auth/sessions | AuthController | authenticated() | - |
+| GET | /api/auth/sessions | AuthController | authenticated() | - |
+| DELETE | /api/auth/sessions/{id} | AuthController | authenticated() | - |
+| GET | /api/convert/configuration | ConvertController | authenticated() | - |
+| PUT | /api/convert/configuration | ConvertController | authenticated() | - |
+| GET | /api/convert/run | ConvertController | authenticated() | - |
+| GET | /api/folders | FolderController | authenticated() | - |
+| GET | /api/folders/drives | FolderController | authenticated() | - |
+| GET | /api/folders/initial | FolderController | authenticated() | - |
+| GET | /api/folders/recent-paths | FolderController | authenticated() | - |
+| GET | /api/home/stats | HomeController | authenticated() | - |
+| GET | /api/preferences | UserPreferenceController | authenticated() | - |
+| PUT | /api/preferences | UserPreferenceController | authenticated() | - |
+| DELETE | /api/recycle-bin | RecycleBinController | authenticated() | - |
+| GET | /api/recycle-bin | RecycleBinController | authenticated() | - |
+| POST | /api/recycle-bin/restore | RecycleBinController | authenticated() | - |
+| GET | /api/search-presets | SearchPresetController | authenticated() | - |
+| POST | /api/search-presets | SearchPresetController | authenticated() | - |
+| DELETE | /api/search-presets/{id} | SearchPresetController | authenticated() | - |
+| GET | /api/sync/configuration | SyncController | authenticated() | - |
+| PUT | /api/sync/configuration | SyncController | authenticated() | - |
+| GET | /api/sync/run | SyncController | authenticated() | - |
+| GET | /api/tags | TagController | authenticated() | - |
+

--- a/JPPhotoManagerWeb/docs/reports/bundle-size/BUNDLE_SIZE_REPORT_2026-08-14.md
+++ b/JPPhotoManagerWeb/docs/reports/bundle-size/BUNDLE_SIZE_REPORT_2026-08-14.md
@@ -1,0 +1,25 @@
+# Bundle Size Report — 2026-08-14
+
+**Commit:** 49eed24
+**Generated:** 2026-08-14T00:46:21.423Z
+**Output path:** dist/jp-photo-manager-ui
+
+**Initial bundle size:** 451.6 kB (main + eagerly-loaded chunks — what every route pays on first load)
+**Budget status:** within budget (warning at 500kb, error at 1mb)
+**Total JS shipped (initial + all lazy routes, excluding source maps):** 1783.0 kB
+**Total dist size (all files):** 2271.7 kB
+
+## Largest 10 JS chunks (initial + lazy combined)
+
+| File | Size (kB) |
+| --- | --- |
+| main-I43AQJ3E.js | 335.1 |
+| chunk-winy1-V7.js | 211.9 |
+| chunk-Ts1I9Ede.js | 188.6 |
+| chunk-CP2f0zRT.js | 179.8 |
+| chunk-DpSaUvh0.js | 107.0 |
+| chunk-D_geS3qA.js | 89.9 |
+| ngsw-worker.js | 84.6 |
+| chunk-ft8vC75b.js | 76.0 |
+| chunk-DySHuxn9.js | 67.9 |
+| chunk-BEhE5Nq4.js | 64.3 |

--- a/JPPhotoManagerWeb/docs/reports/bundle-size/BUNDLE_SIZE_REPORT_2026-08-15.md
+++ b/JPPhotoManagerWeb/docs/reports/bundle-size/BUNDLE_SIZE_REPORT_2026-08-15.md
@@ -1,0 +1,25 @@
+# Bundle Size Report — 2026-08-15
+
+**Commit:** a62ecce
+**Generated:** 2026-08-15T19:48:29.456Z
+**Output path:** dist/jp-photo-manager-ui
+
+**Initial bundle size:** 451.6 kB (main + eagerly-loaded chunks — what every route pays on first load)
+**Budget status:** within budget (warning at 500kb, error at 1mb)
+**Total JS shipped (initial + all lazy routes, excluding source maps):** 1783.0 kB
+**Total dist size (all files):** 2271.7 kB
+
+## Largest 10 JS chunks (initial + lazy combined)
+
+| File | Size (kB) |
+| --- | --- |
+| main-I43AQJ3E.js | 335.1 |
+| chunk-winy1-V7.js | 211.9 |
+| chunk-Ts1I9Ede.js | 188.6 |
+| chunk-CP2f0zRT.js | 179.8 |
+| chunk-DpSaUvh0.js | 107.0 |
+| chunk-D_geS3qA.js | 89.9 |
+| ngsw-worker.js | 84.6 |
+| chunk-ft8vC75b.js | 76.0 |
+| chunk-DySHuxn9.js | 67.9 |
+| chunk-BEhE5Nq4.js | 64.3 |

--- a/JPPhotoManagerWeb/docs/reports/code-coverage/CODE_COVERAGE_REPORT_2026-08-14_backend.md
+++ b/JPPhotoManagerWeb/docs/reports/code-coverage/CODE_COVERAGE_REPORT_2026-08-14_backend.md
@@ -1,0 +1,19 @@
+# Code Coverage Report (backend) — 2026-08-14
+
+**Commit:** f7994d7
+**Generated:** 2026-08-14T20:07:47Z
+**Scope:** backend (target/site/jacoco/jacoco.xml)
+**Gate:** `mvn jacoco:check` enforces 80% minimum line coverage, project-wide (code-reviewer skill §19.2)
+
+**Lines:** 95.28% (4116/4320)
+**Branches:** 83.14% (912/1097)
+**Methods:** 95.81% (870/908)
+
+## 3 class(es) below 80% line coverage
+
+| Class | Line coverage | Lines missed | Lines covered |
+| --- | --- | --- | --- |
+| com/jpablodrexler/photomanager/config/SecurityConfig | 0.0% | 13 | 0 |
+| com/jpablodrexler/photomanager/config/TestSecurityConfig | 42.9% | 4 | 3 |
+| com/jpablodrexler/photomanager/infrastructure/service/AudioMetadataService | 77.3% | 10 | 34 |
+

--- a/JPPhotoManagerWeb/docs/reports/code-coverage/CODE_COVERAGE_REPORT_2026-08-14_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/code-coverage/CODE_COVERAGE_REPORT_2026-08-14_frontend.md
@@ -1,0 +1,19 @@
+# Code Coverage Report (frontend) — 2026-08-14
+
+**Commit:** 64e7da3
+**Generated:** 2026-08-14T23:07:53.902Z
+**Scope:** Cypress Component Testing suite (frontend/src/app/**/*.ts, see .nycrc.json)
+**Gate:** `npm run coverage:check` enforces 80% minimum on all four metrics, project-wide (code-reviewer skill §19.1)
+
+**Statements:** 94.47% (1865/1974)
+**Branches:** 85.55% (456/533)
+**Functions:** 92.7% (597/644)
+**Lines:** 95.63% (1709/1787)
+
+## 3 file(s) below 80% on at least one metric
+
+| File | Statements | Branches | Functions | Lines |
+| --- | --- | --- | --- | --- |
+| src/app/features/gallery/exif-panel/exif-panel.component.ts | 97.1% | **70.45%** | 100% | 100% |
+| src/app/features/gallery/social-media-crop/social-media-crop.component.ts | 90.85% | **76.05%** | 100% | 96.1% |
+| src/app/features/gallery/bulk-tag-dialog/bulk-tag-dialog.component.ts | 95.58% | **79.31%** | 100% | 100% |

--- a/JPPhotoManagerWeb/docs/reports/code-coverage/CODE_COVERAGE_REPORT_2026-08-15_backend.md
+++ b/JPPhotoManagerWeb/docs/reports/code-coverage/CODE_COVERAGE_REPORT_2026-08-15_backend.md
@@ -1,0 +1,19 @@
+# Code Coverage Report (backend) — 2026-08-15
+
+**Commit:** a62ecce
+**Generated:** 2026-08-15T20:29:17Z
+**Scope:** backend (target/site/jacoco/jacoco.xml)
+**Gate:** `mvn jacoco:check` enforces 80% minimum line coverage, project-wide (code-reviewer skill §19.2)
+
+**Lines:** 95.28% (4116/4320)
+**Branches:** 83.14% (912/1097)
+**Methods:** 95.81% (870/908)
+
+## 3 class(es) below 80% line coverage
+
+| Class | Line coverage | Lines missed | Lines covered |
+| --- | --- | --- | --- |
+| com/jpablodrexler/photomanager/config/SecurityConfig | 0.0% | 13 | 0 |
+| com/jpablodrexler/photomanager/config/TestSecurityConfig | 42.9% | 4 | 3 |
+| com/jpablodrexler/photomanager/infrastructure/service/AudioMetadataService | 77.3% | 10 | 34 |
+

--- a/JPPhotoManagerWeb/docs/reports/code-coverage/CODE_COVERAGE_REPORT_2026-08-15_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/code-coverage/CODE_COVERAGE_REPORT_2026-08-15_frontend.md
@@ -1,0 +1,19 @@
+# Code Coverage Report (frontend) — 2026-08-15
+
+**Commit:** a62ecce
+**Generated:** 2026-08-15T19:48:21.707Z
+**Scope:** Cypress Component Testing suite (frontend/src/app/**/*.ts, see .nycrc.json)
+**Gate:** `npm run coverage:check` enforces 80% minimum on all four metrics, project-wide (code-reviewer skill §19.1)
+
+**Statements:** 94.48% (1867/1976)
+**Branches:** 85.55% (456/533)
+**Functions:** 92.72% (599/646)
+**Lines:** 95.64% (1711/1789)
+
+## 3 file(s) below 80% on at least one metric
+
+| File | Statements | Branches | Functions | Lines |
+| --- | --- | --- | --- | --- |
+| src/app/features/gallery/exif-panel/exif-panel.component.ts | 97.1% | **70.45%** | 100% | 100% |
+| src/app/features/gallery/social-media-crop/social-media-crop.component.ts | 90.85% | **76.05%** | 100% | 96.1% |
+| src/app/features/gallery/bulk-tag-dialog/bulk-tag-dialog.component.ts | 95.58% | **79.31%** | 100% | 100% |

--- a/JPPhotoManagerWeb/docs/reports/complexity/COMPLEXITY_REPORT_2026-08-14_backend.md
+++ b/JPPhotoManagerWeb/docs/reports/complexity/COMPLEXITY_REPORT_2026-08-14_backend.md
@@ -1,0 +1,60 @@
+# Complexity & File-Size Hotspots Report (backend) — 2026-08-14
+
+**Commit:** 64e7da3
+**Generated:** 2026-08-14T23:27:10Z
+**Scope:** backend/src/main/java
+
+**Files scanned:** 405
+**Methods analyzed:** 872 (average complexity: 1.63; gate threshold: 15, see `mvn pmd:check`)
+**Average file size:** 35 lines
+
+## Top 20 methods by cyclomatic complexity
+
+| Complexity | Method | Line |
+| --- | --- | --- |
+| 32 | com.jpablodrexler.photomanager.infrastructure.service.StorageServiceAdapter#getExifMetadata | 305 |
+| 15 | com.jpablodrexler.photomanager.application.usecase.asset.GetAssetImageUseCaseImpl#detectMimeType | 42 |
+| 12 | com.jpablodrexler.photomanager.application.usecase.asset.RenameAssetsUseCaseImpl#checkFolderCollisions | 145 |
+| 11 | com.jpablodrexler.photomanager.application.usecase.asset.UploadAssetUseCaseImpl#sanitizeAndValidate | 88 |
+| 10 | com.jpablodrexler.photomanager.infrastructure.service.StorageServiceAdapter#loadImage | 138 |
+| 9 | com.jpablodrexler.photomanager.infrastructure.service.StorageServiceAdapter#getImageRotation | 256 |
+| 9 | com.jpablodrexler.photomanager.infrastructure.persistence.adapter.AssetRepositoryImpl#findFiltered | 80 |
+| 9 | com.jpablodrexler.photomanager.application.usecase.sync.SyncAssetsUseCaseImpl#syncFolder | 81 |
+| 9 | com.jpablodrexler.photomanager.application.usecase.auth.DeviceHintParser#detectOs | 49 |
+| 8 | com.jpablodrexler.photomanager.infrastructure.service.PlsPlaylistParserServiceAdapter#parse | 30 |
+| 8 | com.jpablodrexler.photomanager.infrastructure.service.AudioMetadataService#extractAlbumArt | 53 |
+| 8 | com.jpablodrexler.photomanager.infrastructure.persistence.adapter.AuditLogRepositoryImpl#buildFilterQuery | 51 |
+| 8 | com.jpablodrexler.photomanager.infrastructure.batch.CatalogItemWriteListener#afterJob | 32 |
+| 8 | com.jpablodrexler.photomanager.application.usecase.asset.CropAssetUseCaseImpl#validateCropBounds | 90 |
+| 7 | com.jpablodrexler.photomanager.infrastructure.persistence.adapter.AssetRepositoryImpl#findAllFilteredSortedByDateDesc | 102 |
+| 7 | com.jpablodrexler.photomanager.application.usecase.auth.DeviceHintParser#detectBrowser | 30 |
+| 6 | com.jpablodrexler.photomanager.infrastructure.service.StorageServiceAdapter#applyRotation | 460 |
+| 6 | com.jpablodrexler.photomanager.infrastructure.service.M3uPlaylistParserServiceAdapter#parse | 30 |
+| 6 | com.jpablodrexler.photomanager.infrastructure.service.CatalogFolderServiceAdapter#createAsset | 65 |
+| 6 | com.jpablodrexler.photomanager.infrastructure.service.AudioMetadataService#extract | 30 |
+
+## Top 20 files by line count
+
+| Lines | File |
+| --- | --- |
+| 508 | src/main/java/com/jpablodrexler/photomanager/infrastructure/service/StorageServiceAdapter.java |
+| 486 | src/main/java/com/jpablodrexler/photomanager/infrastructure/web/controller/AssetController.java |
+| 318 | src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/adapter/AssetRepositoryImpl.java |
+| 257 | src/main/java/com/jpablodrexler/photomanager/config/AppConfig.java |
+| 227 | src/main/java/com/jpablodrexler/photomanager/infrastructure/service/CatalogFolderServiceAdapter.java |
+| 227 | src/main/java/com/jpablodrexler/photomanager/application/usecase/asset/RenameAssetsUseCaseImpl.java |
+| 194 | src/main/java/com/jpablodrexler/photomanager/infrastructure/web/exception/GlobalExceptionHandler.java |
+| 181 | src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/jpa/JpaAssetRepository.java |
+| 179 | src/main/java/com/jpablodrexler/photomanager/infrastructure/kafka/AuditLogKafkaListener.java |
+| 176 | src/main/java/com/jpablodrexler/photomanager/infrastructure/batch/CatalogAssetItemProcessor.java |
+| 173 | src/main/java/com/jpablodrexler/photomanager/infrastructure/web/controller/AuthController.java |
+| 168 | src/main/java/com/jpablodrexler/photomanager/infrastructure/batch/CatalogAssetItemWriter.java |
+| 164 | src/main/java/com/jpablodrexler/photomanager/infrastructure/kafka/KafkaProgressListener.java |
+| 158 | src/main/java/com/jpablodrexler/photomanager/infrastructure/web/controller/AlbumController.java |
+| 143 | src/main/java/com/jpablodrexler/photomanager/infrastructure/service/ThumbnailStorageServiceAdapter.java |
+| 135 | src/main/java/com/jpablodrexler/photomanager/infrastructure/web/filter/RateLimitFilter.java |
+| 130 | src/main/java/com/jpablodrexler/photomanager/infrastructure/batch/CatalogJobConfig.java |
+| 123 | src/main/java/com/jpablodrexler/photomanager/application/usecase/sync/SyncAssetsUseCaseImpl.java |
+| 121 | src/main/java/com/jpablodrexler/photomanager/application/usecase/asset/CropAssetUseCaseImpl.java |
+| 119 | src/main/java/com/jpablodrexler/photomanager/application/usecase/asset/MoveAssetsUseCaseImpl.java |
+

--- a/JPPhotoManagerWeb/docs/reports/complexity/COMPLEXITY_REPORT_2026-08-14_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/complexity/COMPLEXITY_REPORT_2026-08-14_frontend.md
@@ -1,0 +1,59 @@
+# Complexity & File-Size Hotspots Report (frontend) — 2026-08-14
+
+**Commit:** 64e7da3
+**Generated:** 2026-08-14T23:25:33.972Z
+**Scope:** frontend/src/app (excludes *.cy.ts, *.spec.ts)
+
+**Files scanned:** 79
+**Functions analyzed:** 656 (average complexity: 1.56; gate threshold: 15, see `npm run complexity`)
+**Average file size:** 69 lines
+
+## Top 20 functions by cyclomatic complexity
+
+| Complexity | File | Line | Function |
+| --- | --- | --- | --- |
+| 21 | src/app/features/gallery/social-media-crop/social-media-crop.component.ts | 234 | getHitArea |
+| 13 | src/app/features/gallery/social-media-crop/social-media-crop.component.ts | 190 | resizeFromCorner |
+| 11 | src/app/features/albums/albums.component.ts | 78 | createAlbum |
+| 11 | src/app/features/gallery/gallery.component.ts | 483 | onKeyDown |
+| 10 | src/app/core/interceptors/auth.interceptor.ts | 31 | <arg-callback> |
+| 9 | src/app/features/gallery/gallery.component.ts | 303 | loadNextPage |
+| 8 | src/app/core/services/asset.service.ts | 20 | getAssets |
+| 8 | src/app/features/gallery/exif-panel/exif-panel.component.ts | 82 | ngOnChanges |
+| 8 | src/app/features/gallery/gallery.component.ts | 370 | loadTimelinePage |
+| 7 | src/app/core/services/media-player.service.ts | 111 | prev |
+| 7 | src/app/features/albums/album-detail/album-detail.component.ts | 63 | filterSummary |
+| 7 | src/app/features/albums/albums.component.ts | 68 | formatFilterSummary |
+| 6 | src/app/core/interceptors/auth.interceptor.ts | 10 | extractErrorMessage |
+| 6 | src/app/core/services/asset.service.ts | 35 | getTimeline |
+| 6 | src/app/features/gallery/exif-panel/exif-panel.component.ts | 116 | addTag |
+| 6 | src/app/features/gallery/gallery.component.ts | 784 | <arg-callback> |
+| 5 | src/app/app.component.ts | 93 | ngDoCheck |
+| 5 | src/app/core/services/auth.service.ts | 41 | scheduleProactiveRefresh |
+| 5 | src/app/core/services/background-sync.service.ts | 34 | replayQueue |
+| 5 | src/app/features/albums/album-detail/edit-album-filter-dialog.component.ts | 76 | constructor |
+
+## Top 20 files by line count
+
+| Lines | File |
+| --- | --- |
+| 995 | src/app/features/gallery/gallery.component.ts |
+| 314 | src/app/features/gallery/social-media-crop/social-media-crop.component.ts |
+| 186 | src/app/app.component.ts |
+| 184 | src/app/features/gallery/drop-zone/drop-zone.component.ts |
+| 176 | src/app/core/services/media-player.service.ts |
+| 165 | src/app/features/gallery/exif-panel/exif-panel.component.ts |
+| 148 | src/app/features/gallery/bulk-tag-dialog/bulk-tag-dialog.component.ts |
+| 136 | src/app/features/convert/convert.component.ts |
+| 136 | src/app/features/sync/sync.component.ts |
+| 132 | src/app/core/services/auth.service.ts |
+| 127 | src/app/core/services/asset.service.ts |
+| 121 | src/app/features/albums/albums.component.ts |
+| 115 | src/app/features/admin/users/user-admin.component.ts |
+| 108 | src/app/features/albums/album-detail/album-detail.component.ts |
+| 107 | src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts |
+| 107 | src/app/features/recycle-bin/recycle-bin.component.ts |
+| 101 | src/app/features/folder-nav/folder-nav.component.ts |
+| 99 | src/app/features/albums/album-detail/edit-album-filter-dialog.component.ts |
+| 91 | src/app/shared/components/thumbnail/thumbnail.component.ts |
+| 86 | src/app/features/gallery/add-to-album-dialog/add-to-album-dialog.component.ts |

--- a/JPPhotoManagerWeb/docs/reports/complexity/COMPLEXITY_REPORT_2026-08-15_backend.md
+++ b/JPPhotoManagerWeb/docs/reports/complexity/COMPLEXITY_REPORT_2026-08-15_backend.md
@@ -1,0 +1,60 @@
+# Complexity & File-Size Hotspots Report (backend) — 2026-08-15
+
+**Commit:** a62ecce
+**Generated:** 2026-08-15T20:28:53Z
+**Scope:** backend/src/main/java
+
+**Files scanned:** 405
+**Methods analyzed:** 872 (average complexity: 1.63; gate threshold: 15, see `mvn pmd:check`)
+**Average file size:** 35 lines
+
+## Top 20 methods by cyclomatic complexity
+
+| Complexity | Method | Line |
+| --- | --- | --- |
+| 32 | com.jpablodrexler.photomanager.infrastructure.service.StorageServiceAdapter#getExifMetadata | 305 |
+| 15 | com.jpablodrexler.photomanager.application.usecase.asset.GetAssetImageUseCaseImpl#detectMimeType | 42 |
+| 12 | com.jpablodrexler.photomanager.application.usecase.asset.RenameAssetsUseCaseImpl#checkFolderCollisions | 145 |
+| 11 | com.jpablodrexler.photomanager.application.usecase.asset.UploadAssetUseCaseImpl#sanitizeAndValidate | 88 |
+| 10 | com.jpablodrexler.photomanager.infrastructure.service.StorageServiceAdapter#loadImage | 138 |
+| 9 | com.jpablodrexler.photomanager.infrastructure.service.StorageServiceAdapter#getImageRotation | 256 |
+| 9 | com.jpablodrexler.photomanager.infrastructure.persistence.adapter.AssetRepositoryImpl#findFiltered | 80 |
+| 9 | com.jpablodrexler.photomanager.application.usecase.sync.SyncAssetsUseCaseImpl#syncFolder | 81 |
+| 9 | com.jpablodrexler.photomanager.application.usecase.auth.DeviceHintParser#detectOs | 49 |
+| 8 | com.jpablodrexler.photomanager.infrastructure.service.PlsPlaylistParserServiceAdapter#parse | 30 |
+| 8 | com.jpablodrexler.photomanager.infrastructure.service.AudioMetadataService#extractAlbumArt | 53 |
+| 8 | com.jpablodrexler.photomanager.infrastructure.persistence.adapter.AuditLogRepositoryImpl#buildFilterQuery | 51 |
+| 8 | com.jpablodrexler.photomanager.infrastructure.batch.CatalogItemWriteListener#afterJob | 32 |
+| 8 | com.jpablodrexler.photomanager.application.usecase.asset.CropAssetUseCaseImpl#validateCropBounds | 90 |
+| 7 | com.jpablodrexler.photomanager.infrastructure.persistence.adapter.AssetRepositoryImpl#findAllFilteredSortedByDateDesc | 102 |
+| 7 | com.jpablodrexler.photomanager.application.usecase.auth.DeviceHintParser#detectBrowser | 30 |
+| 6 | com.jpablodrexler.photomanager.infrastructure.service.StorageServiceAdapter#applyRotation | 460 |
+| 6 | com.jpablodrexler.photomanager.infrastructure.service.M3uPlaylistParserServiceAdapter#parse | 30 |
+| 6 | com.jpablodrexler.photomanager.infrastructure.service.CatalogFolderServiceAdapter#createAsset | 65 |
+| 6 | com.jpablodrexler.photomanager.infrastructure.service.AudioMetadataService#extract | 30 |
+
+## Top 20 files by line count
+
+| Lines | File |
+| --- | --- |
+| 508 | src/main/java/com/jpablodrexler/photomanager/infrastructure/service/StorageServiceAdapter.java |
+| 486 | src/main/java/com/jpablodrexler/photomanager/infrastructure/web/controller/AssetController.java |
+| 318 | src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/adapter/AssetRepositoryImpl.java |
+| 257 | src/main/java/com/jpablodrexler/photomanager/config/AppConfig.java |
+| 227 | src/main/java/com/jpablodrexler/photomanager/infrastructure/service/CatalogFolderServiceAdapter.java |
+| 227 | src/main/java/com/jpablodrexler/photomanager/application/usecase/asset/RenameAssetsUseCaseImpl.java |
+| 194 | src/main/java/com/jpablodrexler/photomanager/infrastructure/web/exception/GlobalExceptionHandler.java |
+| 181 | src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/jpa/JpaAssetRepository.java |
+| 179 | src/main/java/com/jpablodrexler/photomanager/infrastructure/kafka/AuditLogKafkaListener.java |
+| 176 | src/main/java/com/jpablodrexler/photomanager/infrastructure/batch/CatalogAssetItemProcessor.java |
+| 173 | src/main/java/com/jpablodrexler/photomanager/infrastructure/web/controller/AuthController.java |
+| 168 | src/main/java/com/jpablodrexler/photomanager/infrastructure/batch/CatalogAssetItemWriter.java |
+| 164 | src/main/java/com/jpablodrexler/photomanager/infrastructure/kafka/KafkaProgressListener.java |
+| 158 | src/main/java/com/jpablodrexler/photomanager/infrastructure/web/controller/AlbumController.java |
+| 143 | src/main/java/com/jpablodrexler/photomanager/infrastructure/service/ThumbnailStorageServiceAdapter.java |
+| 135 | src/main/java/com/jpablodrexler/photomanager/infrastructure/web/filter/RateLimitFilter.java |
+| 130 | src/main/java/com/jpablodrexler/photomanager/infrastructure/batch/CatalogJobConfig.java |
+| 123 | src/main/java/com/jpablodrexler/photomanager/application/usecase/sync/SyncAssetsUseCaseImpl.java |
+| 121 | src/main/java/com/jpablodrexler/photomanager/application/usecase/asset/CropAssetUseCaseImpl.java |
+| 119 | src/main/java/com/jpablodrexler/photomanager/application/usecase/asset/MoveAssetsUseCaseImpl.java |
+

--- a/JPPhotoManagerWeb/docs/reports/complexity/COMPLEXITY_REPORT_2026-08-15_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/complexity/COMPLEXITY_REPORT_2026-08-15_frontend.md
@@ -1,0 +1,59 @@
+# Complexity & File-Size Hotspots Report (frontend) — 2026-08-15
+
+**Commit:** a62ecce
+**Generated:** 2026-08-15T19:43:32.094Z
+**Scope:** frontend/src/app (excludes *.cy.ts, *.spec.ts)
+
+**Files scanned:** 79
+**Functions analyzed:** 656 (average complexity: 1.56; gate threshold: 15, see `npm run complexity`)
+**Average file size:** 69 lines
+
+## Top 20 functions by cyclomatic complexity
+
+| Complexity | File | Line | Function |
+| --- | --- | --- | --- |
+| 21 | src/app/features/gallery/social-media-crop/social-media-crop.component.ts | 234 | getHitArea |
+| 13 | src/app/features/gallery/social-media-crop/social-media-crop.component.ts | 190 | resizeFromCorner |
+| 11 | src/app/features/albums/albums.component.ts | 78 | createAlbum |
+| 11 | src/app/features/gallery/gallery.component.ts | 483 | onKeyDown |
+| 10 | src/app/core/interceptors/auth.interceptor.ts | 31 | <arg-callback> |
+| 9 | src/app/features/gallery/gallery.component.ts | 303 | loadNextPage |
+| 8 | src/app/core/services/asset.service.ts | 20 | getAssets |
+| 8 | src/app/features/gallery/exif-panel/exif-panel.component.ts | 82 | ngOnChanges |
+| 8 | src/app/features/gallery/gallery.component.ts | 370 | loadTimelinePage |
+| 7 | src/app/core/services/media-player.service.ts | 111 | prev |
+| 7 | src/app/features/albums/album-detail/album-detail.component.ts | 63 | filterSummary |
+| 7 | src/app/features/albums/albums.component.ts | 68 | formatFilterSummary |
+| 6 | src/app/core/interceptors/auth.interceptor.ts | 10 | extractErrorMessage |
+| 6 | src/app/core/services/asset.service.ts | 35 | getTimeline |
+| 6 | src/app/features/gallery/exif-panel/exif-panel.component.ts | 116 | addTag |
+| 6 | src/app/features/gallery/gallery.component.ts | 784 | <arg-callback> |
+| 5 | src/app/app.component.ts | 93 | ngDoCheck |
+| 5 | src/app/core/services/auth.service.ts | 41 | scheduleProactiveRefresh |
+| 5 | src/app/core/services/background-sync.service.ts | 34 | replayQueue |
+| 5 | src/app/features/albums/album-detail/edit-album-filter-dialog.component.ts | 76 | constructor |
+
+## Top 20 files by line count
+
+| Lines | File |
+| --- | --- |
+| 995 | src/app/features/gallery/gallery.component.ts |
+| 314 | src/app/features/gallery/social-media-crop/social-media-crop.component.ts |
+| 186 | src/app/app.component.ts |
+| 184 | src/app/features/gallery/drop-zone/drop-zone.component.ts |
+| 176 | src/app/core/services/media-player.service.ts |
+| 165 | src/app/features/gallery/exif-panel/exif-panel.component.ts |
+| 148 | src/app/features/gallery/bulk-tag-dialog/bulk-tag-dialog.component.ts |
+| 136 | src/app/features/convert/convert.component.ts |
+| 136 | src/app/features/sync/sync.component.ts |
+| 132 | src/app/core/services/auth.service.ts |
+| 127 | src/app/core/services/asset.service.ts |
+| 121 | src/app/features/albums/albums.component.ts |
+| 115 | src/app/features/admin/users/user-admin.component.ts |
+| 108 | src/app/features/albums/album-detail/album-detail.component.ts |
+| 107 | src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts |
+| 107 | src/app/features/recycle-bin/recycle-bin.component.ts |
+| 101 | src/app/features/folder-nav/folder-nav.component.ts |
+| 99 | src/app/features/albums/album-detail/edit-album-filter-dialog.component.ts |
+| 91 | src/app/shared/components/thumbnail/thumbnail.component.ts |
+| 86 | src/app/features/gallery/add-to-album-dialog/add-to-album-dialog.component.ts |

--- a/JPPhotoManagerWeb/docs/reports/dead-code/DEAD_CODE_REPORT_2026-08-14_backend.md
+++ b/JPPhotoManagerWeb/docs/reports/dead-code/DEAD_CODE_REPORT_2026-08-14_backend.md
@@ -1,0 +1,80 @@
+# Dead Code Report (backend) — 2026-08-14
+
+**Commit:** 64e7da3
+**Generated:** 2026-08-14T23:27:38Z
+**Scope:** backend/pom.xml (via `mvn dependency:analyze`)
+
+Every `spring-boot-starter-*` entry under "Unused declared dependencies" below is expected noise (see this script's own header comment for why) — not a real finding.
+
+```
+[INFO] Scanning for projects...
+[INFO] Building jp-photo-manager 1.0.0-SNAPSHOT
+[INFO]   from pom.xml
+[WARNING] Used undeclared dependencies found:
+[WARNING]    com.fasterxml.jackson.core:jackson-databind:jar:2.19.1:compile
+[WARNING]    org.springframework:spring-tx:jar:6.2.8:compile
+[WARNING]    com.fasterxml.jackson.core:jackson-annotations:jar:2.19.1:compile
+[WARNING]    org.springframework.boot:spring-boot-test:jar:3.5.3:test
+[WARNING]    org.springframework.security:spring-security-crypto:jar:6.5.1:compile
+[WARNING]    org.hamcrest:hamcrest:jar:3.0:test
+[WARNING]    org.springframework.batch:spring-batch-infrastructure:jar:5.2.2:compile
+[WARNING]    org.springframework.security:spring-security-web:jar:6.5.1:compile
+[WARNING]    jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile
+[WARNING]    org.springframework.data:spring-data-commons:jar:3.5.1:compile
+[WARNING]    org.springframework.boot:spring-boot:jar:3.5.3:compile
+[WARNING]    org.slf4j:slf4j-api:jar:2.0.17:compile
+[WARNING]    org.springframework.data:spring-data-mongodb:jar:4.5.1:compile
+[WARNING]    org.springframework.data:spring-data-redis:jar:3.5.1:compile
+[WARNING]    io.micrometer:micrometer-core:jar:1.15.1:compile
+[WARNING]    org.springframework.security:spring-security-config:jar:6.5.1:compile
+[WARNING]    io.swagger.core.v3:swagger-annotations-jakarta:jar:2.2.30:compile
+[WARNING]    org.testcontainers:testcontainers:jar:1.21.2:test
+[WARNING]    org.springframework.data:spring-data-jpa:jar:3.5.1:compile
+[WARNING]    org.springframework.boot:spring-boot-test-autoconfigure:jar:3.5.3:test
+[WARNING]    org.springframework.security:spring-security-core:jar:6.5.1:compile
+[WARNING]    org.mockito:mockito-core:jar:5.17.0:test
+[WARNING]    org.junit.jupiter:junit-jupiter-api:jar:5.12.2:test
+[WARNING]    org.mockito:mockito-junit-jupiter:jar:5.17.0:test
+[WARNING]    org.springframework.batch:spring-batch-core:jar:5.2.2:compile
+[WARNING]    org.hibernate.orm:hibernate-core:jar:6.6.18.Final:compile
+[WARNING]    org.springframework:spring-context:jar:6.2.8:compile
+[WARNING]    org.springframework.boot:spring-boot-autoconfigure:jar:3.5.3:compile
+[WARNING]    com.fasterxml.jackson.core:jackson-core:jar:2.19.1:compile
+[WARNING]    org.springframework:spring-core:jar:6.2.8:compile
+[WARNING]    jakarta.persistence:jakarta.persistence-api:jar:3.1.0:compile
+[WARNING]    org.apache.kafka:kafka-clients:jar:3.9.1:compile
+[WARNING]    org.springframework.boot:spring-boot-actuator:jar:3.5.3:compile
+[WARNING]    org.springframework:spring-webmvc:jar:6.2.8:compile
+[WARNING]    io.lettuce:lettuce-core:jar:6.6.0.RELEASE:compile
+[WARNING]    org.springframework:spring-test:jar:6.2.8:test
+[WARNING]    org.assertj:assertj-core:jar:3.27.3:test
+[WARNING]    org.mongodb:bson:jar:5.5.1:compile
+[WARNING]    org.springframework:spring-beans:jar:6.2.8:compile
+[WARNING]    org.springframework:spring-web:jar:6.2.8:compile
+[WARNING]    jakarta.validation:jakarta.validation-api:jar:3.0.2:compile
+[WARNING]    org.apache.tomcat.embed:tomcat-embed-core:jar:10.1.42:compile
+[WARNING] Unused declared dependencies found:
+[WARNING]    org.springframework.boot:spring-boot-starter-web:jar:3.5.3:compile
+[WARNING]    org.springframework.boot:spring-boot-starter-data-jpa:jar:3.5.3:compile
+[WARNING]    org.springframework.boot:spring-boot-starter-validation:jar:3.5.3:compile
+[WARNING]    org.springframework.boot:spring-boot-starter-actuator:jar:3.5.3:compile
+[WARNING]    io.micrometer:micrometer-registry-prometheus:jar:1.15.1:compile
+[WARNING]    org.postgresql:postgresql:jar:42.7.7:compile
+[WARNING]    org.flywaydb:flyway-core:jar:11.7.2:compile
+[WARNING]    org.flywaydb:flyway-database-postgresql:jar:11.7.2:compile
+[WARNING]    org.kohsuke:github-api:jar:1.321:compile
+[WARNING]    net.logstash.logback:logstash-logback-encoder:jar:8.0:compile
+[WARNING]    org.springframework.boot:spring-boot-starter-data-redis:jar:3.5.3:compile
+[WARNING]    org.springframework.boot:spring-boot-starter-data-mongodb:jar:3.5.3:compile
+[WARNING]    org.springdoc:springdoc-openapi-starter-webmvc-ui:jar:2.8.9:compile
+[WARNING]    org.springframework.boot:spring-boot-starter-batch:jar:3.5.3:compile
+[WARNING]    org.springframework.boot:spring-boot-starter-security:jar:3.5.3:compile
+[WARNING]    io.jsonwebtoken:jjwt-impl:jar:0.12.6:runtime
+[WARNING]    io.jsonwebtoken:jjwt-jackson:jar:0.12.6:runtime
+[WARNING]    org.springframework.boot:spring-boot-starter-test:jar:3.5.3:test
+[WARNING] Non-test scoped test only dependencies found:
+[WARNING]    org.mongodb:bson:jar:5.5.1:compile
+[INFO] BUILD SUCCESS
+[INFO] Total time:  3.940 s
+[INFO] Finished at: 2026-08-14T20:27:44-03:00
+```

--- a/JPPhotoManagerWeb/docs/reports/dead-code/DEAD_CODE_REPORT_2026-08-14_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/dead-code/DEAD_CODE_REPORT_2026-08-14_frontend.md
@@ -1,0 +1,52 @@
+# Dead Code Report (frontend) — 2026-08-14
+
+**Commit:** 64e7da3
+**Generated:** 2026-08-14T23:25:42.148Z
+**Scope:** frontend (see knip.jsonc for entry points and intentional ignores)
+
+**Total findings:** 21 (2 unused file(s), 0 unused export(s), 13 unused type(s), 1 unused dependenc(y/ies), 5 unlisted dependenc(y/ies))
+
+## Unused files
+
+Never imported/referenced from any entry point.
+
+- src/app/core/models/audio-metadata.model.ts
+- src/app/core/models/tag.model.ts
+
+## Unused dependencies
+
+Declared in package.json but never imported — verify still needed before removing (see knip.jsonc for known name-resolved exceptions already excluded).
+
+| Dependency |
+| --- |
+| typescript-eslint |
+
+## Unlisted dependencies
+
+Imported/referenced in source or config but missing from package.json (relying on a transitive install, or referencing a package that was never installed at all — check both) — should be declared directly or removed.
+
+| File | Dependency |
+| --- | --- |
+| angular.json | karma-jasmine |
+| angular.json | karma-chrome-launcher |
+| angular.json | karma-jasmine-html-reporter |
+| angular.json | karma-coverage |
+| angular.json | jasmine-core |
+
+## Unused types
+
+| File | Line | Type |
+| --- | --- | --- |
+| src/app/core/models/album.model.ts | 41 | AlbumAssetIdsRequest |
+| src/app/core/models/asset.model.ts | 1 | ImageRotation |
+| src/app/core/models/asset.model.ts | 2 | FileType |
+| src/app/core/models/asset.model.ts | 27 | ProcessingStatus |
+| src/app/core/models/asset.model.ts | 40 | RenameAssetsRequest |
+| src/app/core/models/analytics.model.ts | 1 | FolderStorageEntry |
+| src/app/core/models/analytics.model.ts | 6 | FormatEntry |
+| src/app/core/models/analytics.model.ts | 11 | MonthlyCountEntry |
+| src/app/core/models/analytics.model.ts | 16 | RatingEntry |
+| src/app/core/models/analytics.model.ts | 33 | ChartSeries |
+| src/app/core/models/catalog-notification.model.ts | 3 | CatalogNotificationAsset |
+| src/app/core/models/background-sync.model.ts | 3 | SyncQueueEntry |
+| src/app/core/models/background-sync.model.ts | 17 | SyncManager |

--- a/JPPhotoManagerWeb/docs/reports/dead-code/DEAD_CODE_REPORT_2026-08-15_backend.md
+++ b/JPPhotoManagerWeb/docs/reports/dead-code/DEAD_CODE_REPORT_2026-08-15_backend.md
@@ -1,0 +1,80 @@
+# Dead Code Report (backend) — 2026-08-15
+
+**Commit:** a62ecce
+**Generated:** 2026-08-15T20:29:12Z
+**Scope:** backend/pom.xml (via `mvn dependency:analyze`)
+
+Every `spring-boot-starter-*` entry under "Unused declared dependencies" below is expected noise (see this script's own header comment for why) — not a real finding.
+
+```
+[INFO] Scanning for projects...
+[INFO] Building jp-photo-manager 1.0.0-SNAPSHOT
+[INFO]   from pom.xml
+[WARNING] Used undeclared dependencies found:
+[WARNING]    com.fasterxml.jackson.core:jackson-databind:jar:2.19.1:compile
+[WARNING]    org.springframework:spring-tx:jar:6.2.8:compile
+[WARNING]    com.fasterxml.jackson.core:jackson-annotations:jar:2.19.1:compile
+[WARNING]    org.springframework.boot:spring-boot-test:jar:3.5.3:test
+[WARNING]    org.springframework.security:spring-security-crypto:jar:6.5.1:compile
+[WARNING]    org.hamcrest:hamcrest:jar:3.0:test
+[WARNING]    org.springframework.batch:spring-batch-infrastructure:jar:5.2.2:compile
+[WARNING]    org.springframework.security:spring-security-web:jar:6.5.1:compile
+[WARNING]    jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile
+[WARNING]    org.springframework.data:spring-data-commons:jar:3.5.1:compile
+[WARNING]    org.springframework.boot:spring-boot:jar:3.5.3:compile
+[WARNING]    org.slf4j:slf4j-api:jar:2.0.17:compile
+[WARNING]    org.springframework.data:spring-data-mongodb:jar:4.5.1:compile
+[WARNING]    org.springframework.data:spring-data-redis:jar:3.5.1:compile
+[WARNING]    io.micrometer:micrometer-core:jar:1.15.1:compile
+[WARNING]    org.springframework.security:spring-security-config:jar:6.5.1:compile
+[WARNING]    io.swagger.core.v3:swagger-annotations-jakarta:jar:2.2.30:compile
+[WARNING]    org.testcontainers:testcontainers:jar:1.21.2:test
+[WARNING]    org.springframework.data:spring-data-jpa:jar:3.5.1:compile
+[WARNING]    org.springframework.boot:spring-boot-test-autoconfigure:jar:3.5.3:test
+[WARNING]    org.springframework.security:spring-security-core:jar:6.5.1:compile
+[WARNING]    org.mockito:mockito-core:jar:5.17.0:test
+[WARNING]    org.junit.jupiter:junit-jupiter-api:jar:5.12.2:test
+[WARNING]    org.mockito:mockito-junit-jupiter:jar:5.17.0:test
+[WARNING]    org.springframework.batch:spring-batch-core:jar:5.2.2:compile
+[WARNING]    org.hibernate.orm:hibernate-core:jar:6.6.18.Final:compile
+[WARNING]    org.springframework:spring-context:jar:6.2.8:compile
+[WARNING]    org.springframework.boot:spring-boot-autoconfigure:jar:3.5.3:compile
+[WARNING]    com.fasterxml.jackson.core:jackson-core:jar:2.19.1:compile
+[WARNING]    org.springframework:spring-core:jar:6.2.8:compile
+[WARNING]    jakarta.persistence:jakarta.persistence-api:jar:3.1.0:compile
+[WARNING]    org.apache.kafka:kafka-clients:jar:3.9.1:compile
+[WARNING]    org.springframework.boot:spring-boot-actuator:jar:3.5.3:compile
+[WARNING]    org.springframework:spring-webmvc:jar:6.2.8:compile
+[WARNING]    io.lettuce:lettuce-core:jar:6.6.0.RELEASE:compile
+[WARNING]    org.springframework:spring-test:jar:6.2.8:test
+[WARNING]    org.assertj:assertj-core:jar:3.27.3:test
+[WARNING]    org.mongodb:bson:jar:5.5.1:compile
+[WARNING]    org.springframework:spring-beans:jar:6.2.8:compile
+[WARNING]    org.springframework:spring-web:jar:6.2.8:compile
+[WARNING]    jakarta.validation:jakarta.validation-api:jar:3.0.2:compile
+[WARNING]    org.apache.tomcat.embed:tomcat-embed-core:jar:10.1.42:compile
+[WARNING] Unused declared dependencies found:
+[WARNING]    org.springframework.boot:spring-boot-starter-web:jar:3.5.3:compile
+[WARNING]    org.springframework.boot:spring-boot-starter-data-jpa:jar:3.5.3:compile
+[WARNING]    org.springframework.boot:spring-boot-starter-validation:jar:3.5.3:compile
+[WARNING]    org.springframework.boot:spring-boot-starter-actuator:jar:3.5.3:compile
+[WARNING]    io.micrometer:micrometer-registry-prometheus:jar:1.15.1:compile
+[WARNING]    org.postgresql:postgresql:jar:42.7.7:compile
+[WARNING]    org.flywaydb:flyway-core:jar:11.7.2:compile
+[WARNING]    org.flywaydb:flyway-database-postgresql:jar:11.7.2:compile
+[WARNING]    org.kohsuke:github-api:jar:1.321:compile
+[WARNING]    net.logstash.logback:logstash-logback-encoder:jar:8.0:compile
+[WARNING]    org.springframework.boot:spring-boot-starter-data-redis:jar:3.5.3:compile
+[WARNING]    org.springframework.boot:spring-boot-starter-data-mongodb:jar:3.5.3:compile
+[WARNING]    org.springdoc:springdoc-openapi-starter-webmvc-ui:jar:2.8.9:compile
+[WARNING]    org.springframework.boot:spring-boot-starter-batch:jar:3.5.3:compile
+[WARNING]    org.springframework.boot:spring-boot-starter-security:jar:3.5.3:compile
+[WARNING]    io.jsonwebtoken:jjwt-impl:jar:0.12.6:runtime
+[WARNING]    io.jsonwebtoken:jjwt-jackson:jar:0.12.6:runtime
+[WARNING]    org.springframework.boot:spring-boot-starter-test:jar:3.5.3:test
+[WARNING] Non-test scoped test only dependencies found:
+[WARNING]    org.mongodb:bson:jar:5.5.1:compile
+[INFO] BUILD SUCCESS
+[INFO] Total time:  2.705 s
+[INFO] Finished at: 2026-08-15T17:29:16-03:00
+```

--- a/JPPhotoManagerWeb/docs/reports/dead-code/DEAD_CODE_REPORT_2026-08-15_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/dead-code/DEAD_CODE_REPORT_2026-08-15_frontend.md
@@ -1,0 +1,57 @@
+# Dead Code Report (frontend) — 2026-08-15
+
+**Commit:** a62ecce
+**Generated:** 2026-08-15T19:43:34.767Z
+**Scope:** frontend (see knip.jsonc for entry points and intentional ignores)
+
+**Total findings:** 26 (2 unused file(s), 0 unused export(s), 13 unused type(s), 5 unused dependenc(y/ies), 6 unlisted dependenc(y/ies))
+
+## Unused files
+
+Never imported/referenced from any entry point.
+
+- src/app/core/models/audio-metadata.model.ts
+- src/app/core/models/tag.model.ts
+
+## Unused dependencies
+
+Declared in package.json but never imported — verify still needed before removing (see knip.jsonc for known name-resolved exceptions already excluded).
+
+| Dependency |
+| --- |
+| @secretlint/secretlint-rule-preset-recommend |
+| @stryker-mutator/core |
+| license-checker-rseidelsohn |
+| secretlint |
+| typescript-eslint |
+
+## Unlisted dependencies
+
+Imported/referenced in source or config but missing from package.json (relying on a transitive install, or referencing a package that was never installed at all — check both) — should be declared directly or removed.
+
+| File | Dependency |
+| --- | --- |
+| angular.json | karma-jasmine |
+| angular.json | karma-chrome-launcher |
+| angular.json | karma-jasmine-html-reporter |
+| angular.json | karma-coverage |
+| angular.json | jasmine-core |
+| stryker.conf.mjs | @stryker-mutator/command-runner |
+
+## Unused types
+
+| File | Line | Type |
+| --- | --- | --- |
+| src/app/core/models/album.model.ts | 41 | AlbumAssetIdsRequest |
+| src/app/core/models/asset.model.ts | 1 | ImageRotation |
+| src/app/core/models/asset.model.ts | 2 | FileType |
+| src/app/core/models/asset.model.ts | 27 | ProcessingStatus |
+| src/app/core/models/asset.model.ts | 40 | RenameAssetsRequest |
+| src/app/core/models/analytics.model.ts | 1 | FolderStorageEntry |
+| src/app/core/models/analytics.model.ts | 6 | FormatEntry |
+| src/app/core/models/analytics.model.ts | 11 | MonthlyCountEntry |
+| src/app/core/models/analytics.model.ts | 16 | RatingEntry |
+| src/app/core/models/analytics.model.ts | 33 | ChartSeries |
+| src/app/core/models/catalog-notification.model.ts | 3 | CatalogNotificationAsset |
+| src/app/core/models/background-sync.model.ts | 3 | SyncQueueEntry |
+| src/app/core/models/background-sync.model.ts | 17 | SyncManager |

--- a/JPPhotoManagerWeb/docs/reports/dependency-staleness/DEPENDENCY_STALENESS_REPORT_2026-08-14_backend.md
+++ b/JPPhotoManagerWeb/docs/reports/dependency-staleness/DEPENDENCY_STALENESS_REPORT_2026-08-14_backend.md
@@ -1,0 +1,63 @@
+# Dependency Staleness Report (backend) — 2026-08-14
+
+**Commit:** 49eed24
+**Generated:** 2026-08-14T00:50:42Z
+**Scope:** backend/pom.xml (via versions-maven-plugin)
+
+```
+[INFO] Scanning for projects...
+[INFO] 
+[INFO] ------------------< com.jpablodrexler:photo-manager >-------------------
+[INFO] Building jp-photo-manager 1.0.0-SNAPSHOT
+[INFO]   from pom.xml
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- versions:2.18.0:display-dependency-updates (default-cli) @ photo-manager ---
+[INFO] The following dependencies in Dependencies have newer versions:
+[INFO]   io.github.mweirauch:micrometer-jvm-extras ............. 0.2.2 -> 0.3.0
+[INFO]   io.jsonwebtoken:jjwt-api ............................ 0.12.6 -> 0.13.0
+[INFO]   io.jsonwebtoken:jjwt-impl ........................... 0.12.6 -> 0.13.0
+[INFO]   io.jsonwebtoken:jjwt-jackson ........................ 0.12.6 -> 0.13.0
+[INFO]   io.micrometer:micrometer-registry-prometheus ........ 1.15.1 -> 1.17.0
+[INFO]   net.logstash.logback:logstash-logback-encoder ............. 8.0 -> 9.0
+[INFO]   org.flywaydb:flyway-core ............................ 11.7.2 -> 13.3.0
+[INFO]   org.flywaydb:flyway-database-postgresql ............. 11.7.2 -> 13.3.0
+[INFO]   org.kohsuke:github-api ............................. 1.321 -> 2.0-rc.7
+[INFO]   org.mapstruct:mapstruct ......................... 1.6.3 -> 1.7.0.Beta2
+[INFO]   org.passay:passay ..................................... 1.6.6 -> 2.0.0
+[INFO]   org.postgresql:postgresql .......................... 42.7.7 -> 42.7.13
+[INFO]   org.springdoc:springdoc-openapi-starter-webmvc-ui ..... 2.8.9 -> 3.1.0
+[INFO]   org.springframework.batch:spring-batch-test ........... 5.2.2 -> 6.0.4
+[INFO]   org.springframework.boot:spring-boot-starter-actuator ...
+[INFO]                                                           3.5.3 -> 4.1.0
+[INFO]   org.springframework.boot:spring-boot-starter-batch .... 3.5.3 -> 4.1.0
+[INFO]   org.springframework.boot:spring-boot-starter-data-jpa ...
+[INFO]                                                           3.5.3 -> 4.1.0
+[INFO]   org.springframework.boot:spring-boot-starter-data-mongodb ...
+[INFO]                                                           3.5.3 -> 4.1.0
+[INFO]   org.springframework.boot:spring-boot-starter-data-redis ...
+[INFO]                                                           3.5.3 -> 4.1.0
+[INFO]   org.springframework.boot:spring-boot-starter-security ...
+[INFO]                                                           3.5.3 -> 4.1.0
+[INFO]   org.springframework.boot:spring-boot-starter-test ..... 3.5.3 -> 4.1.0
+[INFO]   org.springframework.boot:spring-boot-starter-validation ...
+[INFO]                                                           3.5.3 -> 4.1.0
+[INFO]   org.springframework.boot:spring-boot-starter-web ...... 3.5.3 -> 4.1.0
+[INFO]   org.springframework.boot:spring-boot-testcontainers ... 3.5.3 -> 4.1.0
+[INFO]   org.springframework.kafka:spring-kafka ................ 3.3.7 -> 4.1.0
+[INFO]   org.springframework.kafka:spring-kafka-test ........... 3.3.7 -> 4.1.0
+[INFO]   org.springframework.security:spring-security-test ..... 6.5.1 -> 7.1.0
+[INFO]   org.testcontainers:junit-jupiter .................... 1.21.2 -> 1.21.4
+[INFO]   org.testcontainers:mongodb .......................... 1.21.2 -> 1.21.4
+[INFO]   org.testcontainers:postgresql ....................... 1.21.2 -> 1.21.4
+[INFO] 
+[INFO] The following dependencies in pluginManagement of plugins have newer versions:
+[INFO]   org.springframework.boot:spring-boot-maven-plugin ..... 3.5.3 -> 4.1.0
+[INFO] 
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  1.315 s
+[INFO] Finished at: 2026-08-13T21:50:45-03:00
+[INFO] ------------------------------------------------------------------------
+```

--- a/JPPhotoManagerWeb/docs/reports/dependency-staleness/DEPENDENCY_STALENESS_REPORT_2026-08-14_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/dependency-staleness/DEPENDENCY_STALENESS_REPORT_2026-08-14_frontend.md
@@ -1,0 +1,31 @@
+# Dependency Staleness Report (frontend) — 2026-08-14
+
+**Commit:** 49eed24
+**Generated:** 2026-08-14T00:45:51.845Z
+**Scope:** frontend/package.json
+
+**Total dependencies (direct):** 37
+**Outdated:** 20 (5 major, 1 minor, 14 patch behind)
+
+| Package | Current | Wanted | Latest | Behind by |
+| --- | --- | --- | --- | --- |
+| @types/node | 22.20.1 | 22.20.1 | 26.2.0 | major |
+| @swimlane/ngx-charts | 24.0.0-alpha.1 | 24.0.2 | 25.0.1 | major |
+| eslint | 9.39.4 | 9.39.5 | 10.8.1 | major |
+| @babel/core | 7.29.7 | 7.29.7 | 8.0.1 | major |
+| typescript | 6.0.3 | 6.0.3 | 7.0.2 | major |
+| zone.js | 0.15.1 | 0.15.1 | 0.16.2 | minor |
+| @angular/build | 22.1.3 | 22.1.4 | 22.1.4 | patch |
+| @angular/cli | 22.1.3 | 22.1.4 | 22.1.4 | patch |
+| @angular/animations | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/cdk | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/common | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/compiler | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/compiler-cli | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/core | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/forms | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/material | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/platform-browser | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/platform-browser-dynamic | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/router | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/service-worker | 22.1.1 | 22.1.2 | 22.1.2 | patch |

--- a/JPPhotoManagerWeb/docs/reports/dependency-staleness/DEPENDENCY_STALENESS_REPORT_2026-08-15_backend.md
+++ b/JPPhotoManagerWeb/docs/reports/dependency-staleness/DEPENDENCY_STALENESS_REPORT_2026-08-15_backend.md
@@ -1,0 +1,65 @@
+# Dependency Staleness Report (backend) — 2026-08-15
+
+**Commit:** a62ecce
+**Generated:** 2026-08-15T20:30:01Z
+**Scope:** backend/pom.xml (via versions-maven-plugin)
+
+```
+[INFO] Scanning for projects...
+[INFO] 
+[INFO] ------------------< com.jpablodrexler:photo-manager >-------------------
+[INFO] Building jp-photo-manager 1.0.0-SNAPSHOT
+[INFO]   from pom.xml
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- versions:2.18.0:display-dependency-updates (default-cli) @ photo-manager ---
+[INFO] The following dependencies in Dependencies have newer versions:
+[INFO]   io.github.mweirauch:micrometer-jvm-extras ............. 0.2.2 -> 0.3.0
+[INFO]   io.jsonwebtoken:jjwt-api ............................ 0.12.6 -> 0.13.0
+[INFO]   io.jsonwebtoken:jjwt-impl ........................... 0.12.6 -> 0.13.0
+[INFO]   io.jsonwebtoken:jjwt-jackson ........................ 0.12.6 -> 0.13.0
+[INFO]   io.micrometer:micrometer-registry-prometheus ........ 1.15.1 -> 1.17.0
+[INFO]   net.logstash.logback:logstash-logback-encoder ............. 8.0 -> 9.0
+[INFO]   org.flywaydb:flyway-core ............................ 11.7.2 -> 13.3.0
+[INFO]   org.flywaydb:flyway-database-postgresql ............. 11.7.2 -> 13.3.0
+[INFO]   org.kohsuke:github-api ............................. 1.321 -> 2.0-rc.7
+[INFO]   org.mapstruct:mapstruct ......................... 1.6.3 -> 1.7.0.Beta2
+[INFO]   org.passay:passay ..................................... 1.6.6 -> 2.0.0
+[INFO]   org.postgresql:postgresql .......................... 42.7.7 -> 42.7.13
+[INFO]   org.springdoc:springdoc-openapi-starter-webmvc-ui ..... 2.8.9 -> 3.1.0
+[INFO]   org.springframework.batch:spring-batch-test ........... 5.2.2 -> 6.0.4
+[INFO]   org.springframework.boot:spring-boot-starter-actuator ...
+[INFO]                                                           3.5.3 -> 4.1.0
+[INFO]   org.springframework.boot:spring-boot-starter-batch .... 3.5.3 -> 4.1.0
+[INFO]   org.springframework.boot:spring-boot-starter-data-jpa ...
+[INFO]                                                           3.5.3 -> 4.1.0
+[INFO]   org.springframework.boot:spring-boot-starter-data-mongodb ...
+[INFO]                                                           3.5.3 -> 4.1.0
+[INFO]   org.springframework.boot:spring-boot-starter-data-redis ...
+[INFO]                                                           3.5.3 -> 4.1.0
+[INFO]   org.springframework.boot:spring-boot-starter-security ...
+[INFO]                                                           3.5.3 -> 4.1.0
+[INFO]   org.springframework.boot:spring-boot-starter-test ..... 3.5.3 -> 4.1.0
+[INFO]   org.springframework.boot:spring-boot-starter-validation ...
+[INFO]                                                           3.5.3 -> 4.1.0
+[INFO]   org.springframework.boot:spring-boot-starter-web ...... 3.5.3 -> 4.1.0
+[INFO]   org.springframework.boot:spring-boot-testcontainers ... 3.5.3 -> 4.1.0
+[INFO]   org.springframework.kafka:spring-kafka ................ 3.3.7 -> 4.1.0
+[INFO]   org.springframework.kafka:spring-kafka-test ........... 3.3.7 -> 4.1.0
+[INFO]   org.springframework.security:spring-security-test ..... 6.5.1 -> 7.1.0
+[INFO]   org.testcontainers:junit-jupiter .................... 1.21.2 -> 1.21.4
+[INFO]   org.testcontainers:mongodb .......................... 1.21.2 -> 1.21.4
+[INFO]   org.testcontainers:postgresql ....................... 1.21.2 -> 1.21.4
+[INFO] 
+[INFO] The following dependencies in pluginManagement of plugins have newer versions:
+[INFO]   org.springframework.boot:spring-boot-maven-plugin ..... 3.5.3 -> 4.1.0
+[INFO] 
+[INFO] No dependencies in Plugin Dependencies have newer versions.
+[INFO] 
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  1.213 s
+[INFO] Finished at: 2026-08-15T17:30:04-03:00
+[INFO] ------------------------------------------------------------------------
+```

--- a/JPPhotoManagerWeb/docs/reports/dependency-staleness/DEPENDENCY_STALENESS_REPORT_2026-08-15_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/dependency-staleness/DEPENDENCY_STALENESS_REPORT_2026-08-15_frontend.md
@@ -1,0 +1,31 @@
+# Dependency Staleness Report (frontend) — 2026-08-15
+
+**Commit:** a62ecce
+**Generated:** 2026-08-15T19:48:31.934Z
+**Scope:** frontend/package.json
+
+**Total dependencies (direct):** 47
+**Outdated:** 20 (5 major, 1 minor, 14 patch behind)
+
+| Package | Current | Wanted | Latest | Behind by |
+| --- | --- | --- | --- | --- |
+| @types/node | 22.20.1 | 22.20.1 | 26.2.0 | major |
+| @swimlane/ngx-charts | 24.0.0-alpha.1 | 24.0.2 | 25.0.1 | major |
+| eslint | 9.39.4 | 9.39.5 | 10.8.1 | major |
+| @babel/core | 7.29.7 | 7.29.7 | 8.0.1 | major |
+| typescript | 6.0.3 | 6.0.3 | 7.0.2 | major |
+| zone.js | 0.15.1 | 0.15.1 | 0.16.2 | minor |
+| @angular/build | 22.1.3 | 22.1.4 | 22.1.4 | patch |
+| @angular/cli | 22.1.3 | 22.1.4 | 22.1.4 | patch |
+| @angular/animations | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/cdk | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/common | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/compiler | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/compiler-cli | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/core | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/forms | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/material | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/platform-browser | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/platform-browser-dynamic | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/router | 22.1.1 | 22.1.2 | 22.1.2 | patch |
+| @angular/service-worker | 22.1.1 | 22.1.2 | 22.1.2 | patch |

--- a/JPPhotoManagerWeb/docs/reports/dependency-vulnerabilities/SCA_REPORT_2026-08-15_backend.md
+++ b/JPPhotoManagerWeb/docs/reports/dependency-vulnerabilities/SCA_REPORT_2026-08-15_backend.md
@@ -1,0 +1,36 @@
+# Dependency Vulnerability (SCA) Report (backend) — 2026-08-15
+
+**Commit:** a62ecce
+**Generated:** 2026-08-15T20:30:08Z
+**Scope:** backend Maven dependency tree, compile scope (OSV.dev batch query, https://api.osv.dev)
+
+**82 known vulnerabilities across the resolved dependency tree.**
+
+| Package | Vuln count | OSV IDs |
+| --- | --- | --- |
+| org.springframework.boot:spring-boot:3.5.3 | 1 | GHSA-wwpq-f5c3-7hvx |
+| org.apache.logging.log4j:log4j-api:2.24.3 | 1 | GHSA-qv9r-c865-cp47 |
+| org.apache.tomcat.embed:tomcat-embed-core:10.1.42 | 19 | GHSA-25xr-qj8w-c4vf, GHSA-563x-q5rq-57qp, GHSA-5m62-pw8w-7w9f, GHSA-5mp6-jrq3-r938, GHSA-9m3c-qcxr-9x87, GHSA-9m89-8frq-c98c, GHSA-fpj8-gq4v-p354, GHSA-fv25-8xcx-gqjc, GHSA-gqp3-2cvr-x8m3, GHSA-gx5v-xp9w-j4cg, GHSA-h6fc-48rj-7qqh, GHSA-hgrr-935x-pq79, GHSA-mgp5-rv84-w37q, GHSA-r29c-68gh-xp6x, GHSA-rv64-5gf8-9qq8, GHSA-vfww-5hm6-hx2j, GHSA-wmwf-9ccg-fff5, GHSA-wr62-c79q-cv37, GHSA-x4m4-345f-5h5g |
+| org.springframework:spring-web:6.2.8 | 1 | GHSA-7m2p-62gw-p8qq |
+| org.springframework:spring-webmvc:6.2.8 | 12 | GHSA-3chg-m5w7-qfv5, GHSA-4773-3jfm-qmx3, GHSA-6hcq-hmm3-jj3c, GHSA-6p4f-wcwh-5vvm, GHSA-72pg-x5f8-j25j, GHSA-957g-f97v-vppc, GHSA-cjpg-rgq5-fr37, GHSA-h3qp-gqrc-q736, GHSA-mq64-j8f9-9gcj, GHSA-r936-gwx5-v52f, GHSA-wg35-8jpf-2xv3, GHSA-x23c-287f-qqv5 |
+| org.springframework:spring-expression:6.2.8 | 3 | GHSA-9f52-rjqv-25qv, GHSA-r5w3-xv2f-j59q, GHSA-wxpp-56q6-5pcg |
+| org.springframework.data:spring-data-commons:3.5.1 | 4 | GHSA-5m4m-73w9-8433, GHSA-5vpf-xvv7-c8vh, GHSA-88fw-v6x4-3f58, GHSA-9fw2-h3hf-293r |
+| org.springframework.boot:spring-boot-starter-actuator:3.5.3 | 2 | GHSA-8hfc-fq58-r658, GHSA-mgvc-8q2h-5pgc |
+| io.micrometer:micrometer-core:1.15.1 | 2 | GHSA-g3pr-3p32-fp23, GHSA-w737-wx49-qj23 |
+| org.postgresql:postgresql:42.7.7 | 2 | GHSA-98qh-xjc8-98pq, GHSA-j92g-9f8w-j867 |
+| com.fasterxml.jackson.core:jackson-core:2.19.1 | 2 | GHSA-72hv-8253-57qq, GHSA-r7wm-3cxj-wff9 |
+| org.apache.commons:commons-lang3:3.17.0 | 1 | GHSA-j288-q9x7-2f5v |
+| com.fasterxml.jackson.core:jackson-databind:2.19.1 | 5 | GHSA-3pjw-73gf-8qr5, GHSA-5jmj-h7xm-6q6v, GHSA-hgj6-7826-r7m5, GHSA-j3rv-43j4-c7qm, GHSA-rmj7-2vxq-3g9f |
+| io.netty:netty-handler:4.1.122.Final | 3 | GHSA-3qp7-7mw8-wx86, GHSA-c653-97m9-rcg9, GHSA-x4gw-5cx5-pgmh |
+| io.netty:netty-codec:4.1.122.Final | 3 | GHSA-3p8m-j85q-pgmj, GHSA-558v-64gr-wgg4, GHSA-mj4r-2hfc-f8p6 |
+| org.springframework.data:spring-data-keyvalue:3.5.1 | 1 | GHSA-xg2j-3hj6-pc24 |
+| org.springframework.data:spring-data-mongodb:4.5.1 | 2 | GHSA-5whc-4q84-fj73, GHSA-hc43-m36c-8v33 |
+| org.springframework.kafka:spring-kafka:3.3.7 | 3 | GHSA-53w6-v7cv-fc9h, GHSA-xq69-5h5v-x9x4, GHSA-xvfq-4q6q-gxx7 |
+| org.springframework.retry:spring-retry:2.0.12 | 1 | GHSA-2827-2mxx-j8pv |
+| org.apache.kafka:kafka-clients:3.9.1 | 2 | GHSA-5qcv-4rpc-jp93, GHSA-wf66-mphr-4c4r |
+| ch.qos.logback:logback-core:1.5.18 | 4 | GHSA-25qh-j22f-pwp8, GHSA-jhq6-gfmj-v8fx, GHSA-p47f-322f-whfh, GHSA-qqpg-mvqg-649v |
+| org.springframework.security:spring-security-web:6.5.1 | 3 | GHSA-293q-567p-wmwq, GHSA-mf92-479x-3373, GHSA-x2r2-rvhq-2mqv |
+| org.springframework:spring-core:6.2.8 | 2 | GHSA-659m-px2c-25wj, GHSA-jmp9-x22r-554x |
+| org.springframework.security:spring-security-core:6.5.1 | 3 | GHSA-8v5q-rhf3-jphm, GHSA-vxf7-qj7q-83fh, GHSA-x2wq-9x2f-fhj7 |
+
+Look up any ID at https://osv.dev/vulnerability/<id> for severity, affected version ranges, and the fixed version — the batch endpoint used here returns IDs only, not full advisory detail, to keep this a fast routine check rather than one HTTP call per finding. A vulnerability in a *test-scope-only* transitive dependency (not shown here — this query is compile-scope only) is lower priority than one reachable at runtime.

--- a/JPPhotoManagerWeb/docs/reports/dependency-vulnerabilities/SCA_REPORT_2026-08-15_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/dependency-vulnerabilities/SCA_REPORT_2026-08-15_frontend.md
@@ -1,0 +1,24 @@
+# Dependency Vulnerability (SCA) Report (frontend) — 2026-08-15
+
+**Commit:** a62ecce
+**Generated:** 2026-08-15T20:28:53.149Z
+**Scope:** `frontend/` npm dependency tree (`npm audit`, npm's own advisory database)
+
+**12 vulnerable package(s):** 0 critical, 7 high, 5 moderate, 0 low, 0 info.
+
+| Package | Severity | Vulnerable range | Fix available | Advisory |
+| --- | --- | --- | --- | --- |
+| @angular-devkit/build-angular | high | <=22.2.0-next.0 | yes (@angular-devkit/build-angular@0.1002.1) | less; webpack-dev-server |
+| brace-expansion | high | <=1.1.17 || 2.0.0 - 2.1.3 || 3.0.0 - 5.0.8 | yes | brace-expansion: Large numeric range defeats documented `max` DoS protection; brace-expansion: DoS via exponential-time expansion of consecutive non-expanding {} groups; brace-expansion: DoS via exponential-time expansion of consecutive non-expanding {} groups; brace-expansion: DoS via exponential-time expansion of consecutive non-expanding {} groups; brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash; brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash; brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash; brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation; brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation; brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation |
+| fast-uri | high | 3.0.0 - 3.1.4 | yes | fast-uri vulnerable to host confusion via literal backslash authority delimiter; fast-uri vulnerable to host confusion via backslash authority introducer; fast-uri vulnerable to path traversal via percent-encoded dot segments; fast-uri vulnerable to host confusion via percent-encoded authority delimiters; fast-uri vulnerable to host confusion via failed IDN canonicalization |
+| image-size | high | * | yes (@angular-devkit/build-angular@0.1002.1) | image-size: ICNS parser allows denial of service through an infinite loop; image-size: JXL and HEIF parsers allow denial of service through infinite loops |
+| js-yaml | high | <=3.15.0 | yes | JS-YAML: Quadratic-complexity DoS in merge key handling via repeated aliases; js-yaml: YAML merge-key chains can force quadratic CPU consumption; JS-YAML: Quadratic CPU consumption in !!omap resolution (3.x and 4.x) — CVE-2026-59870 fix not backported |
+| less | high | 2.2.0 - 4.6.7 | yes (@angular-devkit/build-angular@0.1002.1) | image-size |
+| tmp | high | <0.2.6 | yes | tmp has Path Traversal via unsanitized prefix/postfix that enables directory escape |
+| qs | moderate | 6.11.1 - 6.15.1 | yes | qs has a remotely triggerable DoS: qs.stringify crashes with TypeError on null/undefined entries in comma-format arrays when encodeValuesOnly is set |
+| sockjs | moderate | >=0.3.17 | yes (@angular-devkit/build-angular@0.1002.1) | uuid |
+| typed-rest-client | moderate | 2.3.1 - 3.0.0 | yes | qs |
+| uuid | moderate | <11.1.1 | yes (@angular-devkit/build-angular@0.1002.1) | uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided |
+| webpack-dev-server | moderate | 2.0.0-beta - 5.2.6 | yes (@angular-devkit/build-angular@0.1002.1) | sockjs |
+
+Critical/high severity with a fix available is the priority — `npm audit fix` (or `--force` for a breaking major bump, review the changelog first) resolves those directly. A vulnerability with no fix available needs a judgment call: is the vulnerable code path actually reachable in this app (many advisories are in a devDependency's own build tooling, never shipped or executed against untrusted input), and if so, is there an interim mitigation until upstream publishes a fix.

--- a/JPPhotoManagerWeb/docs/reports/e2e-run/E2E_RUN_REPORT_2026-08-14_mocked.md
+++ b/JPPhotoManagerWeb/docs/reports/e2e-run/E2E_RUN_REPORT_2026-08-14_mocked.md
@@ -1,0 +1,17 @@
+# E2E Run Report (mocked) — 2026-08-14
+
+**Commit:** 49eed24
+**Generated:** 2026-08-14T00:47:08.029Z
+**Total duration:** 16.5s
+**Tests:** 23 (23 passed, 0 failed, 0 skipped)
+**Flaky tests (needed a retry to pass):** 0
+
+## Slowest 5 specs
+
+| Spec | Duration (s) | Tests |
+| --- | --- | --- |
+| cypress\e2e\mocked\gallery.cy.ts | 3.0 | 5 |
+| cypress\e2e\mocked\admin-users.cy.ts | 1.9 | 2 |
+| cypress\e2e\mocked\login.cy.ts | 1.6 | 2 |
+| cypress\e2e\mocked\albums.cy.ts | 1.4 | 2 |
+| cypress\e2e\mocked\convert.cy.ts | 1.2 | 2 |

--- a/JPPhotoManagerWeb/docs/reports/e2e-run/E2E_RUN_REPORT_2026-08-15_mocked.md
+++ b/JPPhotoManagerWeb/docs/reports/e2e-run/E2E_RUN_REPORT_2026-08-15_mocked.md
@@ -1,0 +1,17 @@
+# E2E Run Report (mocked) — 2026-08-15
+
+**Commit:** a62ecce
+**Generated:** 2026-08-15T19:49:13.878Z
+**Total duration:** 15.6s
+**Tests:** 23 (23 passed, 0 failed, 0 skipped)
+**Flaky tests (needed a retry to pass):** 0
+
+## Slowest 5 specs
+
+| Spec | Duration (s) | Tests |
+| --- | --- | --- |
+| cypress\e2e\mocked\gallery.cy.ts | 2.9 | 5 |
+| cypress\e2e\mocked\admin-users.cy.ts | 1.9 | 2 |
+| cypress\e2e\mocked\login.cy.ts | 1.4 | 2 |
+| cypress\e2e\mocked\sync.cy.ts | 1.3 | 2 |
+| cypress\e2e\mocked\albums.cy.ts | 1.2 | 2 |

--- a/JPPhotoManagerWeb/docs/reports/e2e-run/E2E_RUN_REPORT_2026-08-15_real.md
+++ b/JPPhotoManagerWeb/docs/reports/e2e-run/E2E_RUN_REPORT_2026-08-15_real.md
@@ -1,0 +1,16 @@
+# E2E Run Report (real) — 2026-08-15
+
+**Commit:** a62ecce
+**Generated:** 2026-08-15T19:49:37.779Z
+**Total duration:** 13.7s
+**Tests:** 12 (12 passed, 0 failed, 0 skipped)
+**Flaky tests (needed a retry to pass):** 0
+
+## Slowest 5 specs
+
+| Spec | Duration (s) | Tests |
+| --- | --- | --- |
+| cypress\e2e\admin-users.cy.ts | 5.1 | 3 |
+| cypress\e2e\albums.cy.ts | 3.8 | 3 |
+| cypress\e2e\auth.cy.ts | 3.0 | 4 |
+| cypress\e2e\profile-sessions.cy.ts | 1.8 | 2 |

--- a/JPPhotoManagerWeb/docs/reports/license-compliance/LICENSE_COMPLIANCE_REPORT_2026-08-15_backend.md
+++ b/JPPhotoManagerWeb/docs/reports/license-compliance/LICENSE_COMPLIANCE_REPORT_2026-08-15_backend.md
@@ -1,0 +1,14 @@
+# License Compliance Report (backend) — 2026-08-15
+
+**Commit:** a62ecce
+**Generated:** 2026-08-15T20:30:04Z
+**Scope:** backend Maven dependency tree, excluding test scope (license-maven-plugin add-third-party)
+
+**147 package(s) scanned, 0 need action, 1 previously reviewed and accepted.**
+
+## Previously reviewed and accepted
+
+| Component | License(s) | Why it's accepted |
+| --- | --- | --- |
+| jaudiotagger (net.jthink:jaudiotagger:3.0.1 - https://bitbucket.org/ijabz/jaudiotagger) | LGPL | LGPLv3. Confirmed compile-scope, unmodified dependency (no vendored/patched jaudiotagger source anywhere in this repo) consumed only through its public API in a single adapter class (infrastructure/service/AudioMetadataService.java, ~15 lines: AudioFileIO.read() plus getters on the returned AudioFile/Tag/Artwork) — exactly the unmodified dynamic-linking case LGPL permits without imposing copyleft on the consuming application. The only realistic permissive alternative (mp3agic, MIT) is MP3/ID3-only, so swapping would risk a functional regression for FLAC/OGG/M4A files versus jaudiotagger's format-agnostic reader, for zero compliance benefit. |
+

--- a/JPPhotoManagerWeb/docs/reports/license-compliance/LICENSE_COMPLIANCE_REPORT_2026-08-15_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/license-compliance/LICENSE_COMPLIANCE_REPORT_2026-08-15_frontend.md
@@ -1,0 +1,9 @@
+# License Compliance Report (frontend) — 2026-08-15
+
+**Commit:** a62ecce
+**Generated:** 2026-08-15T20:28:49.323Z
+**Scope:** `frontend/` npm dependency tree (license-checker-rseidelsohn, excludes private/unpublished packages)
+
+**1324 package(s) scanned, 0 flagged** (copyleft license or no resolvable license).
+
+No copyleft or unresolvable licenses found among scanned dependencies.

--- a/JPPhotoManagerWeb/docs/reports/lighthouse/LIGHTHOUSE_REPORT_2026-08-14_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/lighthouse/LIGHTHOUSE_REPORT_2026-08-14_frontend.md
@@ -1,0 +1,16 @@
+# Lighthouse Report (frontend) — 2026-08-14
+
+**Commit:** 64e7da3
+**Generated:** 2026-08-14T23:33:03.416Z
+**Build:** production (`ng build --configuration production`), self-hosted — not the `ng serve` dev build, so scores reflect real optimized output.
+**Scope:** /login — the only route reachable without an authenticated session; every other route requires signing in first, which this report doesn't attempt to simulate.
+
+| Route | Performance | Accessibility | Best Practices | SEO |
+| --- | --- | --- | --- | --- |
+| /login | 70 | 98 | 96 | 82 |
+
+## Accessibility audit failures
+
+| Route | Audit |
+| --- | --- |
+| /login | Document does not have a main landmark. (`landmark-one-main`) |

--- a/JPPhotoManagerWeb/docs/reports/lighthouse/LIGHTHOUSE_REPORT_2026-08-15_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/lighthouse/LIGHTHOUSE_REPORT_2026-08-15_frontend.md
@@ -1,0 +1,16 @@
+# Lighthouse Report (frontend) — 2026-08-15
+
+**Commit:** a62ecce
+**Generated:** 2026-08-15T19:43:55.540Z
+**Build:** production (`ng build --configuration production`), self-hosted — not the `ng serve` dev build, so scores reflect real optimized output.
+**Scope:** /login — the only route reachable without an authenticated session; every other route requires signing in first, which this report doesn't attempt to simulate.
+
+| Route | Performance | Accessibility | Best Practices | SEO |
+| --- | --- | --- | --- | --- |
+| /login | 66 | 98 | 100 | 82 |
+
+## Accessibility audit failures
+
+| Route | Audit |
+| --- | --- |
+| /login | Document does not have a main landmark. (`landmark-one-main`) |

--- a/JPPhotoManagerWeb/docs/reports/mutation/MUTATION_REPORT_2026-08-15_backend.md
+++ b/JPPhotoManagerWeb/docs/reports/mutation/MUTATION_REPORT_2026-08-15_backend.md
@@ -1,0 +1,159 @@
+# Mutation Testing Report (backend) — 2026-08-15
+
+**Commit:** cdb2dbf
+**Generated:** 2026-08-15T03:28:22Z
+**Scope:** com.jpablodrexler.photomanager.application.usecase.* (65 classes)
+**Tool:** PIT (`mvn org.pitest:pitest-maven:mutationCoverage@mutation-report`)
+
+**Line coverage:** 97% (1016/1049)
+**Mutation coverage:** 84% (374/443)
+**Test strength:** 87%
+**Total mutants:** 443
+**Killed:** 374  **Survived:** 54  **No coverage:** 15  **Timed out:** 0  **Non-viable:** 0  **Other:** 0
+
+A survived mutant means the test suite ran and passed even though the mutated line changed the code's behavior — the tests exercise that code path but don't actually assert on the behavior a bug there would break. A "no coverage" mutant means no test reaches that line at all.
+
+## Per-class results (worst mutation score first)
+
+| Class | Score | Total | Killed | Survived | No cov | Timed out |
+| --- | --- | --- | --- | --- | --- | --- |
+| com.jpablodrexler.photomanager.application.usecase.search.CreateSearchPresetUseCaseImpl | 33.3% | 6 | 2 | 4 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.album.CreateAlbumUseCaseImpl | 42.9% | 7 | 3 | 4 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.convert.ConvertAssetsUseCaseImpl | 56.2% | 16 | 9 | 5 | 2 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.asset.UploadAssetUseCaseImpl | 60.0% | 25 | 15 | 10 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.asset.CropAssetUseCaseImpl | 65.6% | 32 | 21 | 10 | 1 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.sync.SyncAssetsUseCaseImpl | 66.7% | 24 | 16 | 6 | 2 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.asset.DownloadAssetsUseCaseImpl | 71.4% | 7 | 5 | 2 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.album.GetAlbumAssetsUseCaseImpl | 75.0% | 4 | 3 | 0 | 1 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.folder.GetSubFoldersUseCaseImpl | 75.0% | 4 | 3 | 1 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.user.CreateUserUseCaseImpl | 75.0% | 8 | 6 | 2 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.album.GetAlbumsUseCaseImpl | 80.0% | 5 | 4 | 0 | 1 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.auth.GetActiveSessionsUseCaseImpl | 80.0% | 5 | 4 | 1 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.catalog.CatalogAssetsUseCaseImpl | 80.0% | 5 | 4 | 0 | 1 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.asset.MoveAssetsUseCaseImpl | 84.0% | 25 | 21 | 2 | 2 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.asset.GetAssetsTimelineUseCaseImpl | 85.7% | 7 | 6 | 1 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.auth.DeviceHintParser | 88.9% | 36 | 32 | 1 | 3 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.catalog.GetDuplicatedAssetsUseCaseImpl | 88.9% | 9 | 8 | 0 | 1 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.auth.RevokeSessionUseCaseImpl | 90.0% | 10 | 9 | 0 | 1 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.asset.RenameAssetsUseCaseImpl | 92.9% | 42 | 39 | 3 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.asset.GetAssetImageUseCaseImpl | 93.1% | 29 | 27 | 2 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.album.AddAssetsToAlbumUseCaseImpl | 100.0% | 3 | 3 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.album.AlbumAssetFilterFactory | 100.0% | 3 | 3 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.album.DeleteAlbumUseCaseImpl | 100.0% | 2 | 2 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.album.GetAlbumSummaryUseCaseImpl | 100.0% | 3 | 3 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.album.RemoveAssetsFromAlbumUseCaseImpl | 100.0% | 3 | 3 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.album.UpdateAlbumUseCaseImpl | 100.0% | 6 | 6 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.analytics.GetAnalyticsUseCaseImpl | 100.0% | 9 | 9 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.asset.DeleteAssetsUseCaseImpl | 100.0% | 5 | 5 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.asset.GetAssetExifUseCaseImpl | 100.0% | 2 | 2 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.asset.GetAssetThumbnailUseCaseImpl | 100.0% | 1 | 1 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.asset.GetAssetsUseCaseImpl | 100.0% | 1 | 1 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.asset.GetPlaylistUseCaseImpl | 100.0% | 5 | 5 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.asset.RateAssetUseCaseImpl | 100.0% | 4 | 4 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.asset.ReprocessAssetUseCaseImpl | 100.0% | 3 | 3 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.asset.StreamAssetUseCaseImpl | 100.0% | 3 | 3 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.audit.GetAuditLogUseCaseImpl | 100.0% | 4 | 4 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.auth.LoginUseCaseImpl | 100.0% | 1 | 1 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.auth.LogoutUseCaseImpl | 100.0% | 2 | 2 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.auth.RefreshTokenUseCaseImpl | 100.0% | 1 | 1 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.convert.GetConvertConfigUseCaseImpl | 100.0% | 1 | 1 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.convert.SaveConvertConfigUseCaseImpl | 100.0% | 5 | 5 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.folder.GetDrivesUseCaseImpl | 100.0% | 1 | 1 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.folder.GetFolderIdByPathUseCaseImpl | 100.0% | 1 | 1 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.folder.GetInitialFolderUseCaseImpl | 100.0% | 1 | 1 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.folder.GetRecentTargetPathsUseCaseImpl | 100.0% | 1 | 1 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.folder.PruneDeletedFoldersUseCaseImpl | 100.0% | 8 | 8 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.home.GetHomeStatsUseCaseImpl | 100.0% | 2 | 2 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.preference.GetUserPreferenceUseCaseImpl | 100.0% | 1 | 1 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.preference.SaveUserPreferenceUseCaseImpl | 100.0% | 1 | 1 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.recycle.GetDeletedAssetsUseCaseImpl | 100.0% | 1 | 1 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.recycle.PurgeAssetsUseCaseImpl | 100.0% | 4 | 4 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.recycle.RestoreAssetsUseCaseImpl | 100.0% | 1 | 1 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.search.DeleteSearchPresetUseCaseImpl | 100.0% | 2 | 2 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.search.GetSearchPresetsUseCaseImpl | 100.0% | 1 | 1 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.sync.GetSyncConfigUseCaseImpl | 100.0% | 1 | 1 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.sync.SaveSyncConfigUseCaseImpl | 100.0% | 5 | 5 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.tag.AddTagToAssetUseCaseImpl | 100.0% | 8 | 8 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.tag.BulkAddTagUseCaseImpl | 100.0% | 5 | 5 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.tag.BulkRemoveTagUseCaseImpl | 100.0% | 6 | 6 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.tag.ListTagsUseCaseImpl | 100.0% | 2 | 2 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.tag.RemoveTagFromAssetUseCaseImpl | 100.0% | 9 | 9 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.user.DeleteUserUseCaseImpl | 100.0% | 2 | 2 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.user.GetCurrentUserUseCaseImpl | 100.0% | 2 | 2 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.user.ListUsersUseCaseImpl | 100.0% | 2 | 2 | 0 | 0 | 0 |
+| com.jpablodrexler.photomanager.application.usecase.user.UpdatePasswordUseCaseImpl | 100.0% | 3 | 3 | 0 | 0 | 0 |
+
+## 69 surviving / uncovered mutant(s)
+
+| Class | Method | Line | Mutator | Status |
+| --- | --- | --- | --- | --- |
+| com.jpablodrexler.photomanager.application.usecase.album.CreateAlbumUseCaseImpl | execute | 29 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.album.CreateAlbumUseCaseImpl | execute | 30 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.album.CreateAlbumUseCaseImpl | execute | 31 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.album.CreateAlbumUseCaseImpl | execute | 32 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.album.GetAlbumAssetsUseCaseImpl | lambda$execute$0 | 28 | NullReturnValsMutator | NO_COVERAGE |
+| com.jpablodrexler.photomanager.application.usecase.album.GetAlbumsUseCaseImpl | countAssets | 40 | PrimitiveReturnsMutator | NO_COVERAGE |
+| com.jpablodrexler.photomanager.application.usecase.asset.CropAssetUseCaseImpl | buildOutputFileName | 103 | ConditionalsBoundaryMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.CropAssetUseCaseImpl | execute | 65 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.CropAssetUseCaseImpl | execute | 67 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.CropAssetUseCaseImpl | lambda$execute$0 | 43 | NullReturnValsMutator | NO_COVERAGE |
+| com.jpablodrexler.photomanager.application.usecase.asset.CropAssetUseCaseImpl | lambda$execute$1 | 86 | NullReturnValsMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.CropAssetUseCaseImpl | toJpegBytes | 112 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.CropAssetUseCaseImpl | toJpegBytes | 117 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.CropAssetUseCaseImpl | validateCropBounds | 92 | ConditionalsBoundaryMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.CropAssetUseCaseImpl | validateCropBounds | 92 | ConditionalsBoundaryMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.CropAssetUseCaseImpl | validateCropBounds | 93 | MathMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.CropAssetUseCaseImpl | validateCropBounds | 94 | MathMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.DownloadAssetsUseCaseImpl | execute | 59 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.DownloadAssetsUseCaseImpl | execute | 60 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.GetAssetImageUseCaseImpl | detectMimeType | 49 | ConditionalsBoundaryMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.GetAssetImageUseCaseImpl | detectMimeType | 56 | ConditionalsBoundaryMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.GetAssetsTimelineUseCaseImpl | execute | 53 | ConditionalsBoundaryMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.MoveAssetsUseCaseImpl | execute | 50 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.MoveAssetsUseCaseImpl | lambda$execute$1 | 53 | NullReturnValsMutator | NO_COVERAGE |
+| com.jpablodrexler.photomanager.application.usecase.asset.MoveAssetsUseCaseImpl | revertFileOperation | 91 | VoidMethodCallMutator | NO_COVERAGE |
+| com.jpablodrexler.photomanager.application.usecase.asset.MoveAssetsUseCaseImpl | saveRecentTargetPath | 114 | ConditionalsBoundaryMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.RenameAssetsUseCaseImpl | applyRenames | 192 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.RenameAssetsUseCaseImpl | baseNameOf | 128 | ConditionalsBoundaryMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.RenameAssetsUseCaseImpl | extensionOf | 133 | ConditionalsBoundaryMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.UploadAssetUseCaseImpl | execute | 59 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.UploadAssetUseCaseImpl | execute | 60 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.UploadAssetUseCaseImpl | execute | 61 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.UploadAssetUseCaseImpl | execute | 62 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.UploadAssetUseCaseImpl | execute | 63 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.UploadAssetUseCaseImpl | execute | 64 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.UploadAssetUseCaseImpl | execute | 65 | NegateConditionalsMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.UploadAssetUseCaseImpl | execute | 65 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.UploadAssetUseCaseImpl | execute | 67 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.asset.UploadAssetUseCaseImpl | execute | 68 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.auth.DeviceHintParser | detectBrowser | 35 | EmptyObjectReturnValsMutator | NO_COVERAGE |
+| com.jpablodrexler.photomanager.application.usecase.auth.DeviceHintParser | detectOs | 57 | EmptyObjectReturnValsMutator | NO_COVERAGE |
+| com.jpablodrexler.photomanager.application.usecase.auth.DeviceHintParser | detectOs | 60 | EmptyObjectReturnValsMutator | NO_COVERAGE |
+| com.jpablodrexler.photomanager.application.usecase.auth.DeviceHintParser | detectOs | 65 | EmptyObjectReturnValsMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.auth.GetActiveSessionsUseCaseImpl | sortKey | 46 | NegateConditionalsMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.auth.RevokeSessionUseCaseImpl | lambda$currentUser$0 | 60 | NullReturnValsMutator | NO_COVERAGE |
+| com.jpablodrexler.photomanager.application.usecase.catalog.CatalogAssetsUseCaseImpl | execute | 61 | NullReturnValsMutator | NO_COVERAGE |
+| com.jpablodrexler.photomanager.application.usecase.catalog.GetDuplicatedAssetsUseCaseImpl | lambda$execute$0 | 33 | BooleanTrueReturnValsMutator | NO_COVERAGE |
+| com.jpablodrexler.photomanager.application.usecase.convert.ConvertAssetsUseCaseImpl | convertDirectory | 57 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.convert.ConvertAssetsUseCaseImpl | convertDirectory | 58 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.convert.ConvertAssetsUseCaseImpl | convertDirectory | 62 | NegateConditionalsMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.convert.ConvertAssetsUseCaseImpl | convertDirectory | 63 | VoidMethodCallMutator | NO_COVERAGE |
+| com.jpablodrexler.photomanager.application.usecase.convert.ConvertAssetsUseCaseImpl | convertDirectory | 84 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.convert.ConvertAssetsUseCaseImpl | execute | 46 | NullReturnValsMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.convert.ConvertAssetsUseCaseImpl | execute | 49 | NullReturnValsMutator | NO_COVERAGE |
+| com.jpablodrexler.photomanager.application.usecase.folder.GetSubFoldersUseCaseImpl | execute | 24 | EmptyObjectReturnValsMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.search.CreateSearchPresetUseCaseImpl | execute | 37 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.search.CreateSearchPresetUseCaseImpl | execute | 38 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.search.CreateSearchPresetUseCaseImpl | execute | 39 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.search.CreateSearchPresetUseCaseImpl | execute | 40 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.sync.SyncAssetsUseCaseImpl | execute | 48 | NullReturnValsMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.sync.SyncAssetsUseCaseImpl | execute | 51 | NullReturnValsMutator | NO_COVERAGE |
+| com.jpablodrexler.photomanager.application.usecase.sync.SyncAssetsUseCaseImpl | syncDirectories | 60 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.sync.SyncAssetsUseCaseImpl | syncDirectories | 64 | NegateConditionalsMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.sync.SyncAssetsUseCaseImpl | syncDirectories | 65 | VoidMethodCallMutator | NO_COVERAGE |
+| com.jpablodrexler.photomanager.application.usecase.sync.SyncAssetsUseCaseImpl | syncDirectories | 71 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.sync.SyncAssetsUseCaseImpl | syncDirectories | 74 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.sync.SyncAssetsUseCaseImpl | syncDirectories | 75 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.user.CreateUserUseCaseImpl | execute | 34 | VoidMethodCallMutator | SURVIVED |
+| com.jpablodrexler.photomanager.application.usecase.user.CreateUserUseCaseImpl | execute | 36 | VoidMethodCallMutator | SURVIVED |
+

--- a/JPPhotoManagerWeb/docs/reports/mutation/MUTATION_REPORT_2026-08-15_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/mutation/MUTATION_REPORT_2026-08-15_frontend.md
@@ -1,0 +1,31 @@
+# Mutation Testing Report (frontend) — 2026-08-15
+
+**Commit:** cdb2dbf
+**Generated:** 2026-08-15T03:32:43.671Z
+**Scope:** curated core/ files with genuine branching logic, see stryker.conf.mjs `mutate` (thin CRUD-wrapper services excluded)
+**Tool:** StrykerJS command runner (`npx stryker run`), driving a scoped `cypress run --component --spec` invocation per mutant
+
+**Overall mutation score:** 99.82% (552/553 detected, excluding 0 ignored + 0 compile errors)
+**Total mutants generated:** 553
+**Killed:** 552  **Survived:** 1  **Timeout:** 0  **No coverage:** 0  **Runtime errors:** 0  **Compile errors:** 0  **Ignored:** 0
+
+A survived mutant means the test suite ran and passed even though the mutated line changed the code's behavior — the tests exercise that code path but don't actually assert on the behavior a bug there would break. A "no coverage" mutant means no test reaches that line at all.
+
+## Per-file results (worst mutation score first)
+
+| File | Score | Total | Killed | Survived | Timeout | No cov | Runtime err | Compile err | Ignored |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| src/app/core/error-handler/global-error-handler.ts | 88.89% | 9 | 8 | 1 | 0 | 0 | 0 | 0 | 0 |
+| src/app/core/interceptors/auth.interceptor.ts | 100.00% | 66 | 66 | 0 | 0 | 0 | 0 | 0 | 0 |
+| src/app/core/services/asset.service.ts | 100.00% | 103 | 103 | 0 | 0 | 0 | 0 | 0 | 0 |
+| src/app/core/services/auth.service.ts | 100.00% | 94 | 94 | 0 | 0 | 0 | 0 | 0 | 0 |
+| src/app/core/services/background-sync.service.ts | 100.00% | 45 | 45 | 0 | 0 | 0 | 0 | 0 | 0 |
+| src/app/core/services/folder.service.ts | 100.00% | 15 | 15 | 0 | 0 | 0 | 0 | 0 | 0 |
+| src/app/core/services/media-player.service.ts | 100.00% | 174 | 174 | 0 | 0 | 0 | 0 | 0 | 0 |
+| src/app/core/services/theme.service.ts | 100.00% | 47 | 47 | 0 | 0 | 0 | 0 | 0 | 0 |
+
+## 1 surviving / uncovered mutant(s)
+
+| File | Line | Mutator | Replacement | Status |
+| --- | --- | --- | --- | --- |
+| src/app/core/error-handler/global-error-handler.ts | 16 | LogicalOperator | `error instanceof Error || error.message` | Survived |

--- a/JPPhotoManagerWeb/docs/reports/route-coverage/ROUTE_COVERAGE_REPORT_2026-08-14_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/route-coverage/ROUTE_COVERAGE_REPORT_2026-08-14_frontend.md
@@ -1,0 +1,24 @@
+# Route E2E Coverage Report (frontend) — 2026-08-14
+
+**Commit:** 64e7da3
+**Generated:** 2026-08-14T23:25:35.919Z
+**Scope:** 12 declared routes; 16 E2E spec files (4 real-backend, 12 mocked)
+
+Whether each declared route has at least one literal `cy.visit(...)` in either E2E tier. A route built from a variable rather than a string literal won't be detected by this scan; a parameterized route (`albums/:id`) is matched by its static path prefix instead of an exact string.
+
+| Route | Real-backend tier | Mocked tier |
+| --- | --- | --- |
+| /admin/users | ✓ | ✓ |
+| /albums | ✓ | ✓ |
+| /albums/:id | ✓ | ✓ |
+| /analytics | — | ✓ |
+| /convert | — | ✓ |
+| /duplicates | — | ✓ |
+| /gallery | — | ✓ |
+| /home | — | ✓ |
+| /login | ✓ | ✓ |
+| /profile/sessions | ✓ | ✓ |
+| /recycle-bin | — | ✓ |
+| /sync | — | ✓ |
+
+**Routes with no E2E coverage in either tier:** none

--- a/JPPhotoManagerWeb/docs/reports/route-coverage/ROUTE_COVERAGE_REPORT_2026-08-15_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/route-coverage/ROUTE_COVERAGE_REPORT_2026-08-15_frontend.md
@@ -1,0 +1,24 @@
+# Route E2E Coverage Report (frontend) — 2026-08-15
+
+**Commit:** a62ecce
+**Generated:** 2026-08-15T19:43:35.300Z
+**Scope:** 12 declared routes; 17 E2E spec files (5 real-backend, 12 mocked)
+
+Whether each declared route has at least one literal `cy.visit(...)` in either E2E tier. A route built from a variable rather than a string literal won't be detected by this scan; a parameterized route (`albums/:id`) is matched by its static path prefix instead of an exact string.
+
+| Route | Real-backend tier | Mocked tier |
+| --- | --- | --- |
+| /admin/users | ✓ | ✓ |
+| /albums | ✓ | ✓ |
+| /albums/:id | ✓ | ✓ |
+| /analytics | ✓ | ✓ |
+| /convert | ✓ | ✓ |
+| /duplicates | ✓ | ✓ |
+| /gallery | ✓ | ✓ |
+| /home | ✓ | ✓ |
+| /login | ✓ | ✓ |
+| /profile/sessions | ✓ | ✓ |
+| /recycle-bin | ✓ | ✓ |
+| /sync | ✓ | ✓ |
+
+**Routes with no E2E coverage in either tier:** none

--- a/JPPhotoManagerWeb/docs/reports/secrets-scan/SECRETS_SCAN_REPORT_2026-08-15.md
+++ b/JPPhotoManagerWeb/docs/reports/secrets-scan/SECRETS_SCAN_REPORT_2026-08-15.md
@@ -1,0 +1,9 @@
+# Secrets Scan Report — 2026-08-15
+
+**Commit:** a62ecce
+**Generated:** 2026-08-15T20:28:41.418Z
+**Scope:** whole repository (secretlint, `.gitignore`-respecting — see `JPPhotoManagerWeb/frontend/.secretlintrc.json` / `.secretlintignore`)
+
+**Findings:** 0 potential secret(s).
+
+No secrets detected.

--- a/JPPhotoManagerWeb/docs/reports/type-coverage/TYPE_COVERAGE_REPORT_2026-08-14.md
+++ b/JPPhotoManagerWeb/docs/reports/type-coverage/TYPE_COVERAGE_REPORT_2026-08-14.md
@@ -1,0 +1,45 @@
+# Type Coverage Report — 2026-08-14
+
+**Commit:** 64e7da3
+**Generated:** 2026-08-14T23:25:36.457Z
+**Scope:** frontend/tsconfig.app.json (application source, excludes *.cy.ts/*.spec.ts)
+
+**Type coverage:** 99.78% (9441 / 9462 identifiers have a non-`any` type)
+**Untyped (`any`) identifiers:** 21, across 6 file(s)
+
+## Files with the most `any`-typed identifiers
+
+| File | Count |
+| --- | --- |
+| src/app/core/interceptors/auth.interceptor.ts | 9 |
+| src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts | 5 |
+| src/app/features/sync/sync.component.ts | 2 |
+| src/app/features/convert/convert.component.ts | 2 |
+| src/main.ts | 2 |
+| src/app/app.component.ts | 1 |
+
+## Every uncovered location
+
+| File | Line | Identifier |
+| --- | --- | --- |
+| src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts | 96 | `message` |
+| src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts | 96 | `error` |
+| src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts | 96 | `message` |
+| src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts | 97 | `error` |
+| src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts | 97 | `message` |
+| src/app/features/sync/sync.component.ts | 114 | `data` |
+| src/app/features/sync/sync.component.ts | 118 | `data` |
+| src/app/features/convert/convert.component.ts | 114 | `data` |
+| src/app/features/convert/convert.component.ts | 118 | `data` |
+| src/app/core/interceptors/auth.interceptor.ts | 10 | `error` |
+| src/app/core/interceptors/auth.interceptor.ts | 30 | `error` |
+| src/app/core/interceptors/auth.interceptor.ts | 32 | `error` |
+| src/app/core/interceptors/auth.interceptor.ts | 39 | `refreshError` |
+| src/app/core/interceptors/auth.interceptor.ts | 42 | `refreshError` |
+| src/app/core/interceptors/auth.interceptor.ts | 45 | `refreshError` |
+| src/app/core/interceptors/auth.interceptor.ts | 51 | `error` |
+| src/app/core/interceptors/auth.interceptor.ts | 59 | `error` |
+| src/app/core/interceptors/auth.interceptor.ts | 63 | `error` |
+| src/app/app.component.ts | 118 | `data` |
+| src/main.ts | 5 | `err` |
+| src/main.ts | 5 | `err` |

--- a/JPPhotoManagerWeb/docs/reports/type-coverage/TYPE_COVERAGE_REPORT_2026-08-15.md
+++ b/JPPhotoManagerWeb/docs/reports/type-coverage/TYPE_COVERAGE_REPORT_2026-08-15.md
@@ -1,0 +1,45 @@
+# Type Coverage Report — 2026-08-15
+
+**Commit:** a62ecce
+**Generated:** 2026-08-15T19:43:31.326Z
+**Scope:** frontend/tsconfig.app.json (application source, excludes *.cy.ts/*.spec.ts)
+
+**Type coverage:** 99.78% (9441 / 9462 identifiers have a non-`any` type)
+**Untyped (`any`) identifiers:** 21, across 6 file(s)
+
+## Files with the most `any`-typed identifiers
+
+| File | Count |
+| --- | --- |
+| src/app/core/interceptors/auth.interceptor.ts | 9 |
+| src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts | 5 |
+| src/app/features/sync/sync.component.ts | 2 |
+| src/app/features/convert/convert.component.ts | 2 |
+| src/main.ts | 2 |
+| src/app/app.component.ts | 1 |
+
+## Every uncovered location
+
+| File | Line | Identifier |
+| --- | --- | --- |
+| src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts | 96 | `message` |
+| src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts | 96 | `error` |
+| src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts | 96 | `message` |
+| src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts | 97 | `error` |
+| src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts | 97 | `message` |
+| src/app/features/sync/sync.component.ts | 114 | `data` |
+| src/app/features/sync/sync.component.ts | 118 | `data` |
+| src/app/features/convert/convert.component.ts | 114 | `data` |
+| src/app/features/convert/convert.component.ts | 118 | `data` |
+| src/app/core/interceptors/auth.interceptor.ts | 10 | `error` |
+| src/app/core/interceptors/auth.interceptor.ts | 30 | `error` |
+| src/app/core/interceptors/auth.interceptor.ts | 32 | `error` |
+| src/app/core/interceptors/auth.interceptor.ts | 39 | `refreshError` |
+| src/app/core/interceptors/auth.interceptor.ts | 42 | `refreshError` |
+| src/app/core/interceptors/auth.interceptor.ts | 45 | `refreshError` |
+| src/app/core/interceptors/auth.interceptor.ts | 51 | `error` |
+| src/app/core/interceptors/auth.interceptor.ts | 59 | `error` |
+| src/app/core/interceptors/auth.interceptor.ts | 63 | `error` |
+| src/app/app.component.ts | 118 | `data` |
+| src/main.ts | 5 | `err` |
+| src/main.ts | 5 | `err` |


### PR DESCRIPTION
## Summary
- Commit the 15 periodic quality-metric report categories under `JPPhotoManagerWeb/docs/reports/` to git (previously fully gitignored) so their dated snapshots build real trend history over time — per-fix audit reports (code-review, security-review, spec-compliance) stay gitignored, since they're scoped to a single change rather than a recurring metric.
- Add a `quality-metrics` skill that runs the full sweep (`bash scripts/run-all-quality-reports.sh`, covering both the frontend's npm report scripts and the backend's bash/Maven-wrapped ones) and reports trends by reading **every** committed historical report per category-and-side — ordered by each report's embedded `Generated` timestamp, never filename or filesystem mtime, since git doesn't preserve mtimes across a clone/checkout — classifying each metric's shape (flat / steadily improving or declining / volatile / one-off / too little history) across the whole series rather than a single previous-vs-current delta.
- Adapted to this project's actual categories and tooling rather than copied from elsewhere: separate `route-coverage`/`auth-coverage` categories, `_frontend`/`_backend` suffixed series for shared categories, and explicit handling for the two backend reports (`dead-code`, `dependency-staleness`) that wrap raw Maven CLI output with no clean summary line.

## Test plan
- [x] Verified the `.gitignore` change un-ignores exactly the 15 quality-metric category folders (37 existing report files) without pulling in the per-fix review-skill output that shares the same `docs/reports/` tree
- [x] Read through existing report files across both frontend and backend, multiple dates, to confirm the skill's file-pattern and extraction tables match the real report formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)