### PR TITLE
Quality-metrics sweep for 2026-09-06

### DIFF
--- a/JPPhotoManagerWeb/docs/reports/a11y/A11Y_REPORT_2026-09-06_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/a11y/A11Y_REPORT_2026-09-06_frontend.md
@@ -1,0 +1,123 @@
+# Accessibility Audit Report (frontend) — 2026-09-06
+
+**Commit:** c0f4ef0
+**Generated:** 2026-09-06T03:03:03.632Z
+**Scope:** 11 authenticated routes (cypress-axe/axe-core, mocked session + intercepted `/api/**` calls — no live backend), the deep complement to `npm run lighthouse:report`'s Lighthouse accessibility score for `/login`: /home, /gallery, /sync, /convert, /duplicates, /admin/users, /albums, /albums/1, /recycle-bin, /analytics, /profile/sessions.
+
+**Total violations:** 50
+
+## Violations by impact
+
+| Impact | Count |
+| --- | --- |
+| critical | 5 |
+| serious | 13 |
+| moderate | 32 |
+| minor | 0 |
+
+## Violations by route
+
+### `/home` (3)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `color-contrast` | serious | 14 (.active > .mdc-button__label; a[href$="gallery"] > .mdc-button__label; a[href$="sync"] > .mdc-button__label; +11 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `region` | moderate | 24 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); .active > .mdc-button__label; a[href$="gallery"] > .mdc-button__label; +21 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |
+
+### `/gallery` (6)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `aria-treeitem-name` | serious | 1 (mat-tree-node) | Ensure every ARIA treeitem node has an accessible name | [ARIA treeitem nodes should have an accessible name](https://dequeuniversity.com/rules/axe/4.13/aria-treeitem-name?application=axeAPI) |
+| `button-name` | critical | 1 (.mat-mdc-button-disabled) | Ensure buttons have discernible text | [Buttons must have discernible text](https://dequeuniversity.com/rules/axe/4.13/button-name?application=axeAPI) |
+| `color-contrast` | serious | 12 (a[routerlink="/home"] > .mdc-button__label; a[routerlink="/sync"] > .mdc-button__label; a[routerlink="/convert"] > .mdc-button__label; +9 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `page-has-heading-one` | moderate | 1 (html) | Ensure that the page, or at least one of its frames contains a level-one heading | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.13/page-has-heading-one?application=axeAPI) |
+| `region` | moderate | 28 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; +25 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |
+
+### `/sync` (6)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `button-name` | critical | 3 (.mat-mdc-button-disabled.mdc-icon-button[mat-ripple-loader-disabled=""]:nth-child(1); .mat-mdc-button-disabled.mdc-icon-button[mat-ripple-loader-disabled=""]:nth-child(2); .mat-warn) | Ensure buttons have discernible text | [Buttons must have discernible text](https://dequeuniversity.com/rules/axe/4.13/button-name?application=axeAPI) |
+| `color-contrast` | serious | 11 (a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; .active > .mdc-button__label; +8 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `label` | critical | 2 (#mat-mdc-checkbox-0-input; #mat-mdc-checkbox-1-input) | Ensure every form element has a label | [Form elements must have labels](https://dequeuniversity.com/rules/axe/4.13/label?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `page-has-heading-one` | moderate | 1 (html) | Ensure that the page, or at least one of its frames contains a level-one heading | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.13/page-has-heading-one?application=axeAPI) |
+| `region` | moderate | 18 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; +15 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |
+
+### `/convert` (6)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `button-name` | critical | 3 (.mat-mdc-button-disabled.mdc-icon-button[mat-ripple-loader-disabled=""]:nth-child(1); .mat-mdc-button-disabled.mdc-icon-button[mat-ripple-loader-disabled=""]:nth-child(2); .mat-warn) | Ensure buttons have discernible text | [Buttons must have discernible text](https://dequeuniversity.com/rules/axe/4.13/button-name?application=axeAPI) |
+| `color-contrast` | serious | 10 (a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; a[routerlink="/sync"] > .mdc-button__label; +7 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `label` | critical | 1 (#mat-mdc-checkbox-0-input) | Ensure every form element has a label | [Form elements must have labels](https://dequeuniversity.com/rules/axe/4.13/label?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `page-has-heading-one` | moderate | 1 (html) | Ensure that the page, or at least one of its frames contains a level-one heading | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.13/page-has-heading-one?application=axeAPI) |
+| `region` | moderate | 17 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; +14 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |
+
+### `/duplicates` (4)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `color-contrast` | serious | 11 (a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; a[routerlink="/sync"] > .mdc-button__label; +8 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `page-has-heading-one` | moderate | 1 (html) | Ensure that the page, or at least one of its frames contains a level-one heading | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.13/page-has-heading-one?application=axeAPI) |
+| `region` | moderate | 18 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; +15 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |
+
+### `/admin/users` (4)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `color-contrast` | serious | 10 (a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; a[routerlink="/sync"] > .mdc-button__label; +7 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `page-has-heading-one` | moderate | 1 (html) | Ensure that the page, or at least one of its frames contains a level-one heading | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.13/page-has-heading-one?application=axeAPI) |
+| `region` | moderate | 18 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; +15 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |
+
+### `/albums` (4)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `color-contrast` | serious | 10 (a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; a[routerlink="/sync"] > .mdc-button__label; +7 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `page-has-heading-one` | moderate | 1 (html) | Ensure that the page, or at least one of its frames contains a level-one heading | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.13/page-has-heading-one?application=axeAPI) |
+| `region` | moderate | 15 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; +12 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |
+
+### `/albums/1` (4)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `color-contrast` | serious | 9 (a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; a[routerlink="/sync"] > .mdc-button__label; +6 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `page-has-heading-one` | moderate | 1 (html) | Ensure that the page, or at least one of its frames contains a level-one heading | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.13/page-has-heading-one?application=axeAPI) |
+| `region` | moderate | 14 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; +11 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |
+
+### `/recycle-bin` (4)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `color-contrast` | serious | 9 (a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; a[routerlink="/sync"] > .mdc-button__label; +6 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `page-has-heading-one` | moderate | 1 (html) | Ensure that the page, or at least one of its frames contains a level-one heading | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.13/page-has-heading-one?application=axeAPI) |
+| `region` | moderate | 14 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; +11 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |
+
+### `/analytics` (5)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `color-contrast` | serious | 9 (a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; a[routerlink="/sync"] > .mdc-button__label; +6 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `page-has-heading-one` | moderate | 1 (html) | Ensure that the page, or at least one of its frames contains a level-one heading | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.13/page-has-heading-one?application=axeAPI) |
+| `region` | moderate | 17 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; +14 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |
+| `scrollable-region-focusable` | serious | 1 (.app-content) | Ensure elements that have scrollable content are accessible by keyboard in Safari | [Scrollable region must have keyboard access](https://dequeuniversity.com/rules/axe/4.13/scrollable-region-focusable?application=axeAPI) |
+
+### `/profile/sessions` (4)
+
+| Rule | Impact | Nodes | Description | Help |
+| --- | --- | --- | --- | --- |
+| `color-contrast` | serious | 10 (a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; a[routerlink="/sync"] > .mdc-button__label; +7 more) | Ensure the contrast between foreground and background colors meets WCAG 2 AA minimum contrast ratio thresholds | [Elements must meet minimum color contrast ratio thresholds](https://dequeuniversity.com/rules/axe/4.13/color-contrast?application=axeAPI) |
+| `landmark-one-main` | moderate | 1 (html) | Ensure the document has a main landmark | [Document should have one main landmark](https://dequeuniversity.com/rules/axe/4.13/landmark-one-main?application=axeAPI) |
+| `page-has-heading-one` | moderate | 1 (html) | Ensure that the page, or at least one of its frames contains a level-one heading | [Page should contain a level-one heading](https://dequeuniversity.com/rules/axe/4.13/page-has-heading-one?application=axeAPI) |
+| `region` | moderate | 18 (span[_ngcontent-ng-c3661584105=""]:nth-child(2); a[routerlink="/home"] > .mdc-button__label; a[routerlink="/gallery"] > .mdc-button__label; +15 more) | Ensure all page content is contained by landmarks | [All page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.13/region?application=axeAPI) |

--- a/JPPhotoManagerWeb/docs/reports/auth-coverage/AUTH_COVERAGE_REPORT_2026-09-06_backend.md
+++ b/JPPhotoManagerWeb/docs/reports/auth-coverage/AUTH_COVERAGE_REPORT_2026-09-06_backend.md
@@ -1,0 +1,74 @@
+# Auth Coverage Report (backend) — 2026-09-06
+
+**Commit:** c0f4ef0
+**Generated:** 2026-09-06T03:46:44Z
+**Scope:** 63 endpoints across infrastructure/web/controller/*.java, resolved against SecurityConfig.java's ordered requestMatchers rules
+
+Factual snapshot of which SecurityConfig rule governs each endpoint — not a pass/fail gate. An endpoint resolving to the `anyRequest` fallback isn't automatically wrong (SecurityConfig's own fallback is `permitAll()`, and some endpoints are intentionally public), but it means no explicit `requestMatchers` rule covers it — worth a second look if that endpoint touches user data. `@PreAuthorize` (if present) is a real, separate, tighter restriction this table doesn't attempt to merge into the "Governing rule" column — read both.
+
+| Method | Path | Controller | Governing rule | @PreAuthorize |
+| --- | --- | --- | --- | --- |
+| GET | /api/admin/users | UserAdminController | hasRole("ADMIN") | - |
+| POST | /api/admin/users | UserAdminController | hasRole("ADMIN") | - |
+| DELETE | /api/admin/users/{id} | UserAdminController | hasRole("ADMIN") | - |
+| PATCH | /api/admin/users/{id}/password | UserAdminController | hasRole("ADMIN") | - |
+| GET | /api/albums | AlbumController | authenticated() | - |
+| POST | /api/albums | AlbumController | authenticated() | - |
+| DELETE | /api/albums/{id} | AlbumController | authenticated() | - |
+| GET | /api/albums/{id} | AlbumController | authenticated() | - |
+| PUT | /api/albums/{id} | AlbumController | authenticated() | - |
+| DELETE | /api/albums/{id}/assets | AlbumController | authenticated() | - |
+| POST | /api/albums/{id}/assets | AlbumController | authenticated() | - |
+| GET | /api/analytics | AnalyticsController | authenticated() | - |
+| DELETE | /api/assets | AssetController | authenticated() | hasRole('ADMIN') |
+| GET | /api/assets | AssetController | authenticated() | - |
+| GET | /api/assets/catalog | AssetController | authenticated() | hasRole('ADMIN') |
+| GET | /api/assets/catalog/observe | AssetController | authenticated() | - |
+| POST | /api/assets/download | AssetController | authenticated() | - |
+| GET | /api/assets/duplicates | AssetController | authenticated() | - |
+| POST | /api/assets/move | AssetController | authenticated() | - |
+| POST | /api/assets/rename | AssetController | authenticated() | - |
+| DELETE | /api/assets/tags/bulk | AssetController | authenticated() | - |
+| POST | /api/assets/tags/bulk | AssetController | authenticated() | - |
+| GET | /api/assets/timeline | AssetController | authenticated() | - |
+| POST | /api/assets/upload | AssetController | authenticated() | - |
+| GET | /api/assets/upload/{assetId}/observe | AssetController | authenticated() | - |
+| GET | /api/assets/{assetId}/exif | AssetController | authenticated() | - |
+| GET | /api/assets/{assetId}/image | AssetController | authenticated() | - |
+| GET | /api/assets/{assetId}/thumbnail | AssetController | authenticated() | - |
+| POST | /api/assets/{id}/crop | AssetController | authenticated() | - |
+| PATCH | /api/assets/{id}/rating | AssetController | authenticated() | - |
+| POST | /api/assets/{id}/reprocess | AssetController | authenticated() | hasRole('ADMIN') |
+| GET | /api/assets/{id}/stream | MediaController | authenticated() | - |
+| DELETE | /api/assets/{id}/tags | AssetController | authenticated() | - |
+| POST | /api/assets/{id}/tags | AssetController | authenticated() | - |
+| GET | /api/audio/playlist/{id} | MediaController | authenticated() | - |
+| GET | /api/audit-log | AuditLogController | authenticated() | - |
+| POST | /api/auth/login | AuthController | permitAll() | - |
+| POST | /api/auth/logout | AuthController | permitAll() | - |
+| GET | /api/auth/me | AuthController | authenticated() | - |
+| POST | /api/auth/refresh | AuthController | permitAll() | - |
+| DELETE | /api/auth/sessions | AuthController | authenticated() | - |
+| GET | /api/auth/sessions | AuthController | authenticated() | - |
+| DELETE | /api/auth/sessions/{id} | AuthController | authenticated() | - |
+| GET | /api/convert/configuration | ConvertController | authenticated() | - |
+| PUT | /api/convert/configuration | ConvertController | authenticated() | - |
+| GET | /api/convert/run | ConvertController | authenticated() | - |
+| GET | /api/folders | FolderController | authenticated() | - |
+| GET | /api/folders/drives | FolderController | authenticated() | - |
+| GET | /api/folders/initial | FolderController | authenticated() | - |
+| GET | /api/folders/recent-paths | FolderController | authenticated() | - |
+| GET | /api/home/stats | HomeController | authenticated() | - |
+| GET | /api/preferences | UserPreferenceController | authenticated() | - |
+| PUT | /api/preferences | UserPreferenceController | authenticated() | - |
+| DELETE | /api/recycle-bin | RecycleBinController | authenticated() | - |
+| GET | /api/recycle-bin | RecycleBinController | authenticated() | - |
+| POST | /api/recycle-bin/restore | RecycleBinController | authenticated() | - |
+| GET | /api/search-presets | SearchPresetController | authenticated() | - |
+| POST | /api/search-presets | SearchPresetController | authenticated() | - |
+| DELETE | /api/search-presets/{id} | SearchPresetController | authenticated() | - |
+| GET | /api/sync/configuration | SyncController | authenticated() | - |
+| PUT | /api/sync/configuration | SyncController | authenticated() | - |
+| GET | /api/sync/run | SyncController | authenticated() | - |
+| GET | /api/tags | TagController | authenticated() | - |
+

--- a/JPPhotoManagerWeb/docs/reports/bundle-size/BUNDLE_SIZE_REPORT_2026-09-06.md
+++ b/JPPhotoManagerWeb/docs/reports/bundle-size/BUNDLE_SIZE_REPORT_2026-09-06.md
@@ -1,0 +1,25 @@
+# Bundle Size Report — 2026-09-06
+
+**Commit:** c0f4ef0
+**Generated:** 2026-09-06T03:07:36.116Z
+**Output path:** dist/jp-photo-manager-ui
+
+**Initial bundle size:** 451.6 kB (main + eagerly-loaded chunks — what every route pays on first load)
+**Budget status:** within budget (warning at 500kb, error at 1mb)
+**Total JS shipped (initial + all lazy routes, excluding source maps):** 1783.0 kB
+**Total dist size (all files):** 2271.7 kB
+
+## Largest 10 JS chunks (initial + lazy combined)
+
+| File | Size (kB) |
+| --- | --- |
+| main-I43AQJ3E.js | 335.1 |
+| chunk-winy1-V7.js | 211.9 |
+| chunk-Ts1I9Ede.js | 188.6 |
+| chunk-CP2f0zRT.js | 179.8 |
+| chunk-DpSaUvh0.js | 107.0 |
+| chunk-D_geS3qA.js | 89.9 |
+| ngsw-worker.js | 84.6 |
+| chunk-ft8vC75b.js | 76.0 |
+| chunk-DySHuxn9.js | 67.9 |
+| chunk-BEhE5Nq4.js | 64.3 |

--- a/JPPhotoManagerWeb/docs/reports/code-coverage/CODE_COVERAGE_REPORT_2026-09-06_backend.md
+++ b/JPPhotoManagerWeb/docs/reports/code-coverage/CODE_COVERAGE_REPORT_2026-09-06_backend.md
@@ -1,0 +1,19 @@
+# Code Coverage Report (backend) — 2026-09-06
+
+**Commit:** c0f4ef0
+**Generated:** 2026-09-06T03:46:44Z
+**Scope:** backend (target/site/jacoco/jacoco.xml)
+**Gate:** `mvn jacoco:check` enforces 80% minimum line coverage, project-wide (code-reviewer skill §19.2)
+
+**Lines:** 95.28% (4116/4320)
+**Branches:** 83.14% (912/1097)
+**Methods:** 95.81% (870/908)
+
+## 3 class(es) below 80% line coverage
+
+| Class | Line coverage | Lines missed | Lines covered |
+| --- | --- | --- | --- |
+| com/jpablodrexler/photomanager/config/SecurityConfig | 0.0% | 13 | 0 |
+| com/jpablodrexler/photomanager/config/TestSecurityConfig | 42.9% | 4 | 3 |
+| com/jpablodrexler/photomanager/infrastructure/service/AudioMetadataService | 77.3% | 10 | 34 |
+

--- a/JPPhotoManagerWeb/docs/reports/code-coverage/CODE_COVERAGE_REPORT_2026-09-06_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/code-coverage/CODE_COVERAGE_REPORT_2026-09-06_frontend.md
@@ -1,0 +1,19 @@
+# Code Coverage Report (frontend) — 2026-09-06
+
+**Commit:** c0f4ef0
+**Generated:** 2026-09-06T03:07:28.610Z
+**Scope:** Cypress Component Testing suite (frontend/src/app/**/*.ts, see .nycrc.json)
+**Gate:** `npm run coverage:check` enforces 80% minimum on all four metrics, project-wide (code-reviewer skill §19.1)
+
+**Statements:** 94.48% (1867/1976)
+**Branches:** 85.55% (456/533)
+**Functions:** 92.72% (599/646)
+**Lines:** 95.64% (1711/1789)
+
+## 3 file(s) below 80% on at least one metric
+
+| File | Statements | Branches | Functions | Lines |
+| --- | --- | --- | --- | --- |
+| src/app/features/gallery/exif-panel/exif-panel.component.ts | 97.1% | **70.45%** | 100% | 100% |
+| src/app/features/gallery/social-media-crop/social-media-crop.component.ts | 90.85% | **76.05%** | 100% | 96.1% |
+| src/app/features/gallery/bulk-tag-dialog/bulk-tag-dialog.component.ts | 95.58% | **79.31%** | 100% | 100% |

--- a/JPPhotoManagerWeb/docs/reports/complexity/COMPLEXITY_REPORT_2026-09-06_backend.md
+++ b/JPPhotoManagerWeb/docs/reports/complexity/COMPLEXITY_REPORT_2026-09-06_backend.md
@@ -1,0 +1,60 @@
+# Complexity & File-Size Hotspots Report (backend) — 2026-09-06
+
+**Commit:** c0f4ef0
+**Generated:** 2026-09-06T03:45:48Z
+**Scope:** backend/src/main/java
+
+**Files scanned:** 405
+**Methods analyzed:** 872 (average complexity: 1.63; gate threshold: 15, see `mvn pmd:check`)
+**Average file size:** 35 lines
+
+## Top 20 methods by cyclomatic complexity
+
+| Complexity | Method | Line |
+| --- | --- | --- |
+| 32 | com.jpablodrexler.photomanager.infrastructure.service.StorageServiceAdapter#getExifMetadata | 305 |
+| 15 | com.jpablodrexler.photomanager.application.usecase.asset.GetAssetImageUseCaseImpl#detectMimeType | 42 |
+| 12 | com.jpablodrexler.photomanager.application.usecase.asset.RenameAssetsUseCaseImpl#checkFolderCollisions | 145 |
+| 11 | com.jpablodrexler.photomanager.application.usecase.asset.UploadAssetUseCaseImpl#sanitizeAndValidate | 88 |
+| 10 | com.jpablodrexler.photomanager.infrastructure.service.StorageServiceAdapter#loadImage | 138 |
+| 9 | com.jpablodrexler.photomanager.infrastructure.service.StorageServiceAdapter#getImageRotation | 256 |
+| 9 | com.jpablodrexler.photomanager.infrastructure.persistence.adapter.AssetRepositoryImpl#findFiltered | 80 |
+| 9 | com.jpablodrexler.photomanager.application.usecase.sync.SyncAssetsUseCaseImpl#syncFolder | 81 |
+| 9 | com.jpablodrexler.photomanager.application.usecase.auth.DeviceHintParser#detectOs | 49 |
+| 8 | com.jpablodrexler.photomanager.infrastructure.service.PlsPlaylistParserServiceAdapter#parse | 30 |
+| 8 | com.jpablodrexler.photomanager.infrastructure.service.AudioMetadataService#extractAlbumArt | 53 |
+| 8 | com.jpablodrexler.photomanager.infrastructure.persistence.adapter.AuditLogRepositoryImpl#buildFilterQuery | 51 |
+| 8 | com.jpablodrexler.photomanager.infrastructure.batch.CatalogItemWriteListener#afterJob | 32 |
+| 8 | com.jpablodrexler.photomanager.application.usecase.asset.CropAssetUseCaseImpl#validateCropBounds | 90 |
+| 7 | com.jpablodrexler.photomanager.infrastructure.persistence.adapter.AssetRepositoryImpl#findAllFilteredSortedByDateDesc | 102 |
+| 7 | com.jpablodrexler.photomanager.application.usecase.auth.DeviceHintParser#detectBrowser | 30 |
+| 6 | com.jpablodrexler.photomanager.infrastructure.service.StorageServiceAdapter#applyRotation | 460 |
+| 6 | com.jpablodrexler.photomanager.infrastructure.service.M3uPlaylistParserServiceAdapter#parse | 30 |
+| 6 | com.jpablodrexler.photomanager.infrastructure.service.CatalogFolderServiceAdapter#createAsset | 65 |
+| 6 | com.jpablodrexler.photomanager.infrastructure.service.AudioMetadataService#extract | 30 |
+
+## Top 20 files by line count
+
+| Lines | File |
+| --- | --- |
+| 508 | src/main/java/com/jpablodrexler/photomanager/infrastructure/service/StorageServiceAdapter.java |
+| 486 | src/main/java/com/jpablodrexler/photomanager/infrastructure/web/controller/AssetController.java |
+| 318 | src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/adapter/AssetRepositoryImpl.java |
+| 257 | src/main/java/com/jpablodrexler/photomanager/config/AppConfig.java |
+| 227 | src/main/java/com/jpablodrexler/photomanager/infrastructure/service/CatalogFolderServiceAdapter.java |
+| 227 | src/main/java/com/jpablodrexler/photomanager/application/usecase/asset/RenameAssetsUseCaseImpl.java |
+| 194 | src/main/java/com/jpablodrexler/photomanager/infrastructure/web/exception/GlobalExceptionHandler.java |
+| 181 | src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/jpa/JpaAssetRepository.java |
+| 179 | src/main/java/com/jpablodrexler/photomanager/infrastructure/kafka/AuditLogKafkaListener.java |
+| 176 | src/main/java/com/jpablodrexler/photomanager/infrastructure/batch/CatalogAssetItemProcessor.java |
+| 173 | src/main/java/com/jpablodrexler/photomanager/infrastructure/web/controller/AuthController.java |
+| 168 | src/main/java/com/jpablodrexler/photomanager/infrastructure/batch/CatalogAssetItemWriter.java |
+| 164 | src/main/java/com/jpablodrexler/photomanager/infrastructure/kafka/KafkaProgressListener.java |
+| 158 | src/main/java/com/jpablodrexler/photomanager/infrastructure/web/controller/AlbumController.java |
+| 143 | src/main/java/com/jpablodrexler/photomanager/infrastructure/service/ThumbnailStorageServiceAdapter.java |
+| 135 | src/main/java/com/jpablodrexler/photomanager/infrastructure/web/filter/RateLimitFilter.java |
+| 130 | src/main/java/com/jpablodrexler/photomanager/infrastructure/batch/CatalogJobConfig.java |
+| 123 | src/main/java/com/jpablodrexler/photomanager/application/usecase/sync/SyncAssetsUseCaseImpl.java |
+| 121 | src/main/java/com/jpablodrexler/photomanager/application/usecase/asset/CropAssetUseCaseImpl.java |
+| 119 | src/main/java/com/jpablodrexler/photomanager/application/usecase/asset/MoveAssetsUseCaseImpl.java |
+

--- a/JPPhotoManagerWeb/docs/reports/complexity/COMPLEXITY_REPORT_2026-09-06_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/complexity/COMPLEXITY_REPORT_2026-09-06_frontend.md
@@ -1,0 +1,59 @@
+# Complexity & File-Size Hotspots Report (frontend) — 2026-09-06
+
+**Commit:** c0f4ef0
+**Generated:** 2026-09-06T03:01:49.939Z
+**Scope:** frontend/src/app (excludes *.cy.ts, *.spec.ts)
+
+**Files scanned:** 79
+**Functions analyzed:** 656 (average complexity: 1.56; gate threshold: 15, see `npm run complexity`)
+**Average file size:** 69 lines
+
+## Top 20 functions by cyclomatic complexity
+
+| Complexity | File | Line | Function |
+| --- | --- | --- | --- |
+| 21 | src/app/features/gallery/social-media-crop/social-media-crop.component.ts | 234 | getHitArea |
+| 13 | src/app/features/gallery/social-media-crop/social-media-crop.component.ts | 190 | resizeFromCorner |
+| 11 | src/app/features/albums/albums.component.ts | 78 | createAlbum |
+| 11 | src/app/features/gallery/gallery.component.ts | 483 | onKeyDown |
+| 10 | src/app/core/interceptors/auth.interceptor.ts | 31 | <arg-callback> |
+| 9 | src/app/features/gallery/gallery.component.ts | 303 | loadNextPage |
+| 8 | src/app/core/services/asset.service.ts | 20 | getAssets |
+| 8 | src/app/features/gallery/exif-panel/exif-panel.component.ts | 82 | ngOnChanges |
+| 8 | src/app/features/gallery/gallery.component.ts | 370 | loadTimelinePage |
+| 7 | src/app/core/services/media-player.service.ts | 111 | prev |
+| 7 | src/app/features/albums/album-detail/album-detail.component.ts | 63 | filterSummary |
+| 7 | src/app/features/albums/albums.component.ts | 68 | formatFilterSummary |
+| 6 | src/app/core/interceptors/auth.interceptor.ts | 10 | extractErrorMessage |
+| 6 | src/app/core/services/asset.service.ts | 35 | getTimeline |
+| 6 | src/app/features/gallery/exif-panel/exif-panel.component.ts | 116 | addTag |
+| 6 | src/app/features/gallery/gallery.component.ts | 784 | <arg-callback> |
+| 5 | src/app/app.component.ts | 93 | ngDoCheck |
+| 5 | src/app/core/services/auth.service.ts | 41 | scheduleProactiveRefresh |
+| 5 | src/app/core/services/background-sync.service.ts | 34 | replayQueue |
+| 5 | src/app/features/albums/album-detail/edit-album-filter-dialog.component.ts | 76 | constructor |
+
+## Top 20 files by line count
+
+| Lines | File |
+| --- | --- |
+| 995 | src/app/features/gallery/gallery.component.ts |
+| 314 | src/app/features/gallery/social-media-crop/social-media-crop.component.ts |
+| 186 | src/app/app.component.ts |
+| 184 | src/app/features/gallery/drop-zone/drop-zone.component.ts |
+| 176 | src/app/core/services/media-player.service.ts |
+| 165 | src/app/features/gallery/exif-panel/exif-panel.component.ts |
+| 148 | src/app/features/gallery/bulk-tag-dialog/bulk-tag-dialog.component.ts |
+| 136 | src/app/features/convert/convert.component.ts |
+| 136 | src/app/features/sync/sync.component.ts |
+| 132 | src/app/core/services/auth.service.ts |
+| 127 | src/app/core/services/asset.service.ts |
+| 121 | src/app/features/albums/albums.component.ts |
+| 115 | src/app/features/admin/users/user-admin.component.ts |
+| 108 | src/app/features/albums/album-detail/album-detail.component.ts |
+| 107 | src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts |
+| 107 | src/app/features/recycle-bin/recycle-bin.component.ts |
+| 101 | src/app/features/folder-nav/folder-nav.component.ts |
+| 99 | src/app/features/albums/album-detail/edit-album-filter-dialog.component.ts |
+| 91 | src/app/shared/components/thumbnail/thumbnail.component.ts |
+| 86 | src/app/features/gallery/add-to-album-dialog/add-to-album-dialog.component.ts |

--- a/JPPhotoManagerWeb/docs/reports/dead-code/DEAD_CODE_REPORT_2026-09-06_backend.md
+++ b/JPPhotoManagerWeb/docs/reports/dead-code/DEAD_CODE_REPORT_2026-09-06_backend.md
@@ -1,0 +1,100 @@
+# Dead Code Report (backend) — 2026-09-06
+
+**Commit:** c0f4ef0
+**Generated:** 2026-09-06T03:46:21Z
+**Scope:** backend/pom.xml (via `mvn dependency:analyze`)
+
+Every `spring-boot-starter-*` entry under "Unused declared dependencies" below is expected noise (see this script's own header comment for why) — not a real finding.
+
+```
+[INFO] Scanning for projects...
+[INFO] Building jp-photo-manager 1.0.0-SNAPSHOT
+[INFO]   from pom.xml
+[INFO] Recompiling the module because of changed source code.
+[INFO] Compiling 405 source files with javac [debug parameters release 21] to target\classes
+[WARNING] /D:/Desarrollo/jp-photo-manager/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/web/mapper/AssetWebMapper.java:[33,29] Unmapped target property: "fNumber".
+[WARNING] /D:/Desarrollo/jp-photo-manager/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/mapper/AssetEntityMapper.java:[18,11] Unmapped target property: "isVideo".
+[WARNING] /D:/Desarrollo/jp-photo-manager/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/mapper/UserPreferenceMapper.java:[10,26] Unmapped target property: "updatedAt".
+[WARNING] /D:/Desarrollo/jp-photo-manager/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/web/mapper/FolderWebMapper.java:[10,23] Unmapped target property: "children".
+[WARNING] /D:/Desarrollo/jp-photo-manager/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/persistence/mapper/AssetExifEntityMapper.java:[10,15] Unmapped target property: "fNumber".
+[WARNING] /D:/Desarrollo/jp-photo-manager/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/config/MongoIndexInitializer.java:[33,17] ensureIndex(org.springframework.data.mongodb.core.index.IndexDefinition) in org.springframework.data.mongodb.core.index.IndexOperations has been deprecated and marked for removal
+[WARNING] /D:/Desarrollo/jp-photo-manager/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/config/MongoIndexInitializer.java:[35,17] ensureIndex(org.springframework.data.mongodb.core.index.IndexDefinition) in org.springframework.data.mongodb.core.index.IndexOperations has been deprecated and marked for removal
+[INFO] /D:/Desarrollo/jp-photo-manager/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/web/filter/RateLimitFilter.java: Some input files use or override a deprecated API.
+[INFO] /D:/Desarrollo/jp-photo-manager/JPPhotoManagerWeb/backend/src/main/java/com/jpablodrexler/photomanager/infrastructure/web/filter/RateLimitFilter.java: Recompile with -Xlint:deprecation for details.
+[INFO] Recompiling the module because of changed dependency.
+[INFO] Compiling 174 source files with javac [debug parameters release 21] to target\test-classes
+[WARNING] /D:/Desarrollo/jp-photo-manager/JPPhotoManagerWeb/backend/src/test/java/com/jpablodrexler/photomanager/infrastructure/config/MongoIndexInitializerAuditLogIntegrationTest.java:[78,21] ensureIndex(org.springframework.data.mongodb.core.index.IndexDefinition) in org.springframework.data.mongodb.core.index.IndexOperations has been deprecated and marked for removal
+[WARNING] /D:/Desarrollo/jp-photo-manager/JPPhotoManagerWeb/backend/src/test/java/com/jpablodrexler/photomanager/infrastructure/config/MongoIndexInitializerAuditLogIntegrationTest.java:[80,21] ensureIndex(org.springframework.data.mongodb.core.index.IndexDefinition) in org.springframework.data.mongodb.core.index.IndexOperations has been deprecated and marked for removal
+[WARNING] /D:/Desarrollo/jp-photo-manager/JPPhotoManagerWeb/backend/src/test/java/com/jpablodrexler/photomanager/infrastructure/config/MongoIndexInitializerTest.java:[35,42] ensureIndex(org.springframework.data.mongodb.core.index.IndexDefinition) in org.springframework.data.mongodb.core.index.IndexOperations has been deprecated and marked for removal
+[INFO] /D:/Desarrollo/jp-photo-manager/JPPhotoManagerWeb/backend/src/test/java/com/jpablodrexler/photomanager/application/service/PasswordValidationServiceTest.java: Some input files use or override a deprecated API.
+[INFO] /D:/Desarrollo/jp-photo-manager/JPPhotoManagerWeb/backend/src/test/java/com/jpablodrexler/photomanager/application/service/PasswordValidationServiceTest.java: Recompile with -Xlint:deprecation for details.
+[INFO] /D:/Desarrollo/jp-photo-manager/JPPhotoManagerWeb/backend/src/test/java/com/jpablodrexler/photomanager/application/usecase/catalog/CatalogAssetsUseCaseImplTest.java: Some input files use unchecked or unsafe operations.
+[INFO] /D:/Desarrollo/jp-photo-manager/JPPhotoManagerWeb/backend/src/test/java/com/jpablodrexler/photomanager/application/usecase/catalog/CatalogAssetsUseCaseImplTest.java: Recompile with -Xlint:unchecked for details.
+[WARNING] Used undeclared dependencies found:
+[WARNING]    com.fasterxml.jackson.core:jackson-databind:jar:2.19.1:compile
+[WARNING]    org.springframework:spring-tx:jar:6.2.8:compile
+[WARNING]    com.fasterxml.jackson.core:jackson-annotations:jar:2.19.1:compile
+[WARNING]    org.springframework.boot:spring-boot-test:jar:3.5.3:test
+[WARNING]    org.springframework.security:spring-security-crypto:jar:6.5.1:compile
+[WARNING]    org.hamcrest:hamcrest:jar:3.0:test
+[WARNING]    org.springframework.batch:spring-batch-infrastructure:jar:5.2.2:compile
+[WARNING]    org.springframework.security:spring-security-web:jar:6.5.1:compile
+[WARNING]    jakarta.annotation:jakarta.annotation-api:jar:2.1.1:compile
+[WARNING]    org.springframework.data:spring-data-commons:jar:3.5.1:compile
+[WARNING]    org.springframework.boot:spring-boot:jar:3.5.3:compile
+[WARNING]    org.slf4j:slf4j-api:jar:2.0.17:compile
+[WARNING]    org.springframework.data:spring-data-mongodb:jar:4.5.1:compile
+[WARNING]    org.springframework.data:spring-data-redis:jar:3.5.1:compile
+[WARNING]    io.micrometer:micrometer-core:jar:1.15.1:compile
+[WARNING]    org.springframework.security:spring-security-config:jar:6.5.1:compile
+[WARNING]    io.swagger.core.v3:swagger-annotations-jakarta:jar:2.2.30:compile
+[WARNING]    org.testcontainers:testcontainers:jar:1.21.2:test
+[WARNING]    org.springframework.data:spring-data-jpa:jar:3.5.1:compile
+[WARNING]    org.springframework.boot:spring-boot-test-autoconfigure:jar:3.5.3:test
+[WARNING]    org.springframework.security:spring-security-core:jar:6.5.1:compile
+[WARNING]    org.mockito:mockito-core:jar:5.17.0:test
+[WARNING]    org.junit.jupiter:junit-jupiter-api:jar:5.12.2:test
+[WARNING]    org.mockito:mockito-junit-jupiter:jar:5.17.0:test
+[WARNING]    org.springframework.batch:spring-batch-core:jar:5.2.2:compile
+[WARNING]    org.hibernate.orm:hibernate-core:jar:6.6.18.Final:compile
+[WARNING]    org.springframework:spring-context:jar:6.2.8:compile
+[WARNING]    org.springframework.boot:spring-boot-autoconfigure:jar:3.5.3:compile
+[WARNING]    com.fasterxml.jackson.core:jackson-core:jar:2.19.1:compile
+[WARNING]    org.springframework:spring-core:jar:6.2.8:compile
+[WARNING]    jakarta.persistence:jakarta.persistence-api:jar:3.1.0:compile
+[WARNING]    org.apache.kafka:kafka-clients:jar:3.9.1:compile
+[WARNING]    org.springframework.boot:spring-boot-actuator:jar:3.5.3:compile
+[WARNING]    org.springframework:spring-webmvc:jar:6.2.8:compile
+[WARNING]    io.lettuce:lettuce-core:jar:6.6.0.RELEASE:compile
+[WARNING]    org.springframework:spring-test:jar:6.2.8:test
+[WARNING]    org.assertj:assertj-core:jar:3.27.3:test
+[WARNING]    org.mongodb:bson:jar:5.5.1:compile
+[WARNING]    org.springframework:spring-beans:jar:6.2.8:compile
+[WARNING]    org.springframework:spring-web:jar:6.2.8:compile
+[WARNING]    jakarta.validation:jakarta.validation-api:jar:3.0.2:compile
+[WARNING]    org.apache.tomcat.embed:tomcat-embed-core:jar:10.1.42:compile
+[WARNING] Unused declared dependencies found:
+[WARNING]    org.springframework.boot:spring-boot-starter-web:jar:3.5.3:compile
+[WARNING]    org.springframework.boot:spring-boot-starter-data-jpa:jar:3.5.3:compile
+[WARNING]    org.springframework.boot:spring-boot-starter-validation:jar:3.5.3:compile
+[WARNING]    org.springframework.boot:spring-boot-starter-actuator:jar:3.5.3:compile
+[WARNING]    io.micrometer:micrometer-registry-prometheus:jar:1.15.1:compile
+[WARNING]    org.postgresql:postgresql:jar:42.7.7:compile
+[WARNING]    org.flywaydb:flyway-core:jar:11.7.2:compile
+[WARNING]    org.flywaydb:flyway-database-postgresql:jar:11.7.2:compile
+[WARNING]    org.kohsuke:github-api:jar:1.321:compile
+[WARNING]    net.logstash.logback:logstash-logback-encoder:jar:8.0:compile
+[WARNING]    org.springframework.boot:spring-boot-starter-data-redis:jar:3.5.3:compile
+[WARNING]    org.springframework.boot:spring-boot-starter-data-mongodb:jar:3.5.3:compile
+[WARNING]    org.springdoc:springdoc-openapi-starter-webmvc-ui:jar:2.8.9:compile
+[WARNING]    org.springframework.boot:spring-boot-starter-batch:jar:3.5.3:compile
+[WARNING]    org.springframework.boot:spring-boot-starter-security:jar:3.5.3:compile
+[WARNING]    io.jsonwebtoken:jjwt-impl:jar:0.12.6:runtime
+[WARNING]    io.jsonwebtoken:jjwt-jackson:jar:0.12.6:runtime
+[WARNING]    org.springframework.boot:spring-boot-starter-test:jar:3.5.3:test
+[WARNING] Non-test scoped test only dependencies found:
+[WARNING]    org.mongodb:bson:jar:5.5.1:compile
+[INFO] BUILD SUCCESS
+[INFO] Total time:  21.093 s
+[INFO] Finished at: 2026-09-06T00:46:43-03:00
+```

--- a/JPPhotoManagerWeb/docs/reports/dead-code/DEAD_CODE_REPORT_2026-09-06_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/dead-code/DEAD_CODE_REPORT_2026-09-06_frontend.md
@@ -1,0 +1,57 @@
+# Dead Code Report (frontend) — 2026-09-06
+
+**Commit:** c0f4ef0
+**Generated:** 2026-09-06T03:02:03.702Z
+**Scope:** frontend (see knip.jsonc for entry points and intentional ignores)
+
+**Total findings:** 26 (2 unused file(s), 0 unused export(s), 13 unused type(s), 5 unused dependenc(y/ies), 6 unlisted dependenc(y/ies))
+
+## Unused files
+
+Never imported/referenced from any entry point.
+
+- src/app/core/models/audio-metadata.model.ts
+- src/app/core/models/tag.model.ts
+
+## Unused dependencies
+
+Declared in package.json but never imported — verify still needed before removing (see knip.jsonc for known name-resolved exceptions already excluded).
+
+| Dependency |
+| --- |
+| @secretlint/secretlint-rule-preset-recommend |
+| @stryker-mutator/core |
+| license-checker-rseidelsohn |
+| secretlint |
+| typescript-eslint |
+
+## Unlisted dependencies
+
+Imported/referenced in source or config but missing from package.json (relying on a transitive install, or referencing a package that was never installed at all — check both) — should be declared directly or removed.
+
+| File | Dependency |
+| --- | --- |
+| angular.json | karma-jasmine |
+| angular.json | karma-chrome-launcher |
+| angular.json | karma-jasmine-html-reporter |
+| angular.json | karma-coverage |
+| angular.json | jasmine-core |
+| stryker.conf.mjs | @stryker-mutator/command-runner |
+
+## Unused types
+
+| File | Line | Type |
+| --- | --- | --- |
+| src/app/core/models/album.model.ts | 41 | AlbumAssetIdsRequest |
+| src/app/core/models/asset.model.ts | 1 | ImageRotation |
+| src/app/core/models/asset.model.ts | 2 | FileType |
+| src/app/core/models/asset.model.ts | 27 | ProcessingStatus |
+| src/app/core/models/asset.model.ts | 40 | RenameAssetsRequest |
+| src/app/core/models/analytics.model.ts | 1 | FolderStorageEntry |
+| src/app/core/models/analytics.model.ts | 6 | FormatEntry |
+| src/app/core/models/analytics.model.ts | 11 | MonthlyCountEntry |
+| src/app/core/models/analytics.model.ts | 16 | RatingEntry |
+| src/app/core/models/analytics.model.ts | 33 | ChartSeries |
+| src/app/core/models/catalog-notification.model.ts | 3 | CatalogNotificationAsset |
+| src/app/core/models/background-sync.model.ts | 3 | SyncQueueEntry |
+| src/app/core/models/background-sync.model.ts | 17 | SyncManager |

--- a/JPPhotoManagerWeb/docs/reports/dependency-staleness/DEPENDENCY_STALENESS_REPORT_2026-09-06_backend.md
+++ b/JPPhotoManagerWeb/docs/reports/dependency-staleness/DEPENDENCY_STALENESS_REPORT_2026-09-06_backend.md
@@ -1,0 +1,145 @@
+# Dependency Staleness Report (backend) — 2026-09-06
+
+**Commit:** c0f4ef0
+**Generated:** 2026-09-06T03:47:28Z
+**Scope:** backend/pom.xml (via versions-maven-plugin)
+
+```
+[INFO] Scanning for projects...
+[INFO] 
+[INFO] ------------------< com.jpablodrexler:photo-manager >-------------------
+[INFO] Building jp-photo-manager 1.0.0-SNAPSHOT
+[INFO]   from pom.xml
+[INFO] --------------------------------[ jar ]---------------------------------
+[INFO] 
+[INFO] --- versions:2.18.0:display-dependency-updates (default-cli) @ photo-manager ---
+Downloading from central: https://repo.maven.apache.org/maven2/io/jsonwebtoken/jjwt-impl/maven-metadata.xml
+Downloading from central: https://repo.maven.apache.org/maven2/com/bucket4j/bucket4j-core/maven-metadata.xml
+Downloading from central: https://repo.maven.apache.org/maven2/io/jsonwebtoken/jjwt-api/maven-metadata.xml
+Downloading from central: https://repo.maven.apache.org/maven2/com/bucket4j/bucket4j-redis/maven-metadata.xml
+Downloading from central: https://repo.maven.apache.org/maven2/io/github/mweirauch/micrometer-jvm-extras/maven-metadata.xml
+Progress (1): 1.1 kBProgress (2): 1.1 kB | 901 B                            Downloaded from central: https://repo.maven.apache.org/maven2/io/jsonwebtoken/jjwt-api/maven-metadata.xml (1.1 kB at 3.4 kB/s)
+Downloaded from central: https://repo.maven.apache.org/maven2/com/bucket4j/bucket4j-redis/maven-metadata.xml (901 B at 2.9 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/io/jsonwebtoken/jjwt-jackson/maven-metadata.xml
+Downloading from central: https://repo.maven.apache.org/maven2/io/micrometer/micrometer-registry-prometheus/maven-metadata.xml
+Progress (1): 4.5 kBProgress (1): 8.4 kBProgress (1): 8.4 kB                    Downloaded from central: https://repo.maven.apache.org/maven2/io/micrometer/micrometer-registry-prometheus/maven-metadata.xml (8.4 kB at 105 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/net/jthink/jaudiotagger/maven-metadata.xml
+Progress (1): 1.1 kBProgress (2): 1.1 kB | 595 B                            Downloaded from central: https://repo.maven.apache.org/maven2/io/jsonwebtoken/jjwt-impl/maven-metadata.xml (1.1 kB at 2.3 kB/s)
+Downloaded from central: https://repo.maven.apache.org/maven2/io/github/mweirauch/micrometer-jvm-extras/maven-metadata.xml (595 B at 1.2 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/net/logstash/logback/logstash-logback-encoder/maven-metadata.xml
+Progress (1): 900 B                   Downloading from central: https://repo.maven.apache.org/maven2/org/apache/commons/commons-imaging/maven-metadata.xml
+Downloaded from central: https://repo.maven.apache.org/maven2/com/bucket4j/bucket4j-core/maven-metadata.xml (900 B at 1.8 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/org/flywaydb/flyway-core/maven-metadata.xml
+Progress (1): 1.1 kB                    Downloaded from central: https://repo.maven.apache.org/maven2/io/jsonwebtoken/jjwt-jackson/maven-metadata.xml (1.1 kB at 4.2 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/org/flywaydb/flyway-database-postgresql/maven-metadata.xml
+Progress (1): 4.0 kBProgress (2): 4.0 kB | 391 B                            Downloaded from central: https://repo.maven.apache.org/maven2/org/flywaydb/flyway-database-postgresql/maven-metadata.xml (4.0 kB at 45 kB/s)
+Downloaded from central: https://repo.maven.apache.org/maven2/net/jthink/jaudiotagger/maven-metadata.xml (391 B at 1.6 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/org/mapstruct/mapstruct/maven-metadata.xml
+Downloading from central: https://repo.maven.apache.org/maven2/org/kohsuke/github-api/maven-metadata.xml
+Progress (1): 545 BProgress (2): 545 B | 1.9 kBProgress (3): 545 B | 1.9 kB | 2.1 kB                                     Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/commons/commons-imaging/maven-metadata.xml (545 B at 1.9 kB/s)
+Downloaded from central: https://repo.maven.apache.org/maven2/net/logstash/logback/logstash-logback-encoder/maven-metadata.xml (1.9 kB at 6.6 kB/s)
+Downloaded from central: https://repo.maven.apache.org/maven2/org/mapstruct/mapstruct/maven-metadata.xml (2.1 kB at 29 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/org/passay/passay/maven-metadata.xml
+Downloading from central: https://repo.maven.apache.org/maven2/org/postgresql/postgresql/maven-metadata.xml
+Downloading from central: https://repo.maven.apache.org/maven2/org/projectlombok/lombok/maven-metadata.xml
+Progress (1): 4.8 kBProgress (1): 9.0 kBProgress (1): 10 kB                    Downloaded from central: https://repo.maven.apache.org/maven2/org/flywaydb/flyway-core/maven-metadata.xml (10 kB at 35 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/org/springdoc/springdoc-openapi-starter-webmvc-ui/maven-metadata.xml
+Progress (1): 2.3 kB                    Downloaded from central: https://repo.maven.apache.org/maven2/org/projectlombok/lombok/maven-metadata.xml (2.3 kB at 32 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/batch/spring-batch-test/maven-metadata.xml
+Progress (1): 1.9 kB                    Downloaded from central: https://repo.maven.apache.org/maven2/org/springdoc/springdoc-openapi-starter-webmvc-ui/maven-metadata.xml (1.9 kB at 23 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-actuator/maven-metadata.xml
+Progress (1): 4.0 kBProgress (1): 4.9 kB                    Downloaded from central: https://repo.maven.apache.org/maven2/org/kohsuke/github-api/maven-metadata.xml (4.9 kB at 18 kB/s)
+Progress (1): 4.8 kBProgress (1): 9.2 kBProgress (1): 11 kB                    Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-batch/maven-metadata.xml
+Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-actuator/maven-metadata.xml (11 kB at 124 kB/s)
+Progress (1): 4.8 kBProgress (1): 9.2 kBProgress (1): 10 kB Progress (2): 10 kB | 3.1 kB                            Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-data-jpa/maven-metadata.xml
+Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-batch/maven-metadata.xml (10 kB at 210 kB/s)
+Progress (2): 3.1 kB | 755 B                            Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-data-mongodb/maven-metadata.xml
+Downloaded from central: https://repo.maven.apache.org/maven2/org/passay/passay/maven-metadata.xml (755 B at 2.7 kB/s)
+Progress (1): 7.6 kB                    Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-data-redis/maven-metadata.xml
+Downloaded from central: https://repo.maven.apache.org/maven2/org/postgresql/postgresql/maven-metadata.xml (7.6 kB at 26 kB/s)
+Progress (1): 4.8 kBProgress (1): 9.2 kBProgress (1): 11 kB                    Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-security/maven-metadata.xml
+Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-data-jpa/maven-metadata.xml (11 kB at 140 kB/s)
+Progress (1): 3.8 kB                    Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-test/maven-metadata.xml
+Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/batch/spring-batch-test/maven-metadata.xml (3.8 kB at 15 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-validation/maven-metadata.xml
+Progress (1): 4.9 kBProgress (1): 9.2 kBProgress (1): 10 kB                    Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-test/maven-metadata.xml (10 kB at 250 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-web/maven-metadata.xml
+Progress (1): 4.7 kBProgress (1): 9.0 kBProgress (1): 9.5 kB                    Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-validation/maven-metadata.xml (9.5 kB at 125 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-testcontainers/maven-metadata.xml
+Progress (1): 5.2 kBProgress (1): 8.9 kBProgress (1): 10 kB                    Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-web/maven-metadata.xml (10 kB at 136 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/kafka/spring-kafka/maven-metadata.xml
+Progress (1): 3.3 kB                    Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-testcontainers/maven-metadata.xml (3.3 kB at 45 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/kafka/spring-kafka-test/maven-metadata.xml
+Progress (1): 5.0 kBProgress (1): 9.1 kBProgress (1): 9.1 kB                    Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/kafka/spring-kafka/maven-metadata.xml (9.1 kB at 191 kB/s)
+Progress (1): 4.7 kBProgress (1): 9.1 kBProgress (1): 11 kB Progress (2): 11 kB | 4.7 kBProgress (2): 11 kB | 9.0 kBProgress (2): 11 kB | 11 kB                            Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/security/spring-security-test/maven-metadata.xml
+Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-security/maven-metadata.xml (11 kB at 40 kB/s)
+Progress (2): 11 kB | 4.7 kBProgress (2): 11 kB | 9.0 kBProgress (2): 11 kB | 9.2 kB                            Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-data-mongodb/maven-metadata.xml (11 kB at 35 kB/s)
+Progress (2): 9.2 kB | 4.9 kBProgress (2): 9.2 kB | 9.1 kBProgress (2): 9.2 kB | 9.2 kB                             Downloading from central: https://repo.maven.apache.org/maven2/org/testcontainers/junit-jupiter/maven-metadata.xml
+Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-data-redis/maven-metadata.xml (9.2 kB at 30 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/org/testcontainers/mongodb/maven-metadata.xml
+Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/kafka/spring-kafka-test/maven-metadata.xml (9.2 kB at 112 kB/s)
+Downloading from central: https://repo.maven.apache.org/maven2/org/testcontainers/postgresql/maven-metadata.xml
+Progress (1): 2.4 kB                    Downloaded from central: https://repo.maven.apache.org/maven2/org/testcontainers/junit-jupiter/maven-metadata.xml (2.4 kB at 62 kB/s)
+Progress (1): 3.7 kB                    Downloaded from central: https://repo.maven.apache.org/maven2/org/testcontainers/postgresql/maven-metadata.xml (3.7 kB at 97 kB/s)
+Progress (1): 4.8 kBProgress (1): 8.8 kBProgress (1): 8.9 kB                    Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/security/spring-security-test/maven-metadata.xml (8.9 kB at 33 kB/s)
+Progress (1): 1.7 kB                    Downloaded from central: https://repo.maven.apache.org/maven2/org/testcontainers/mongodb/maven-metadata.xml (1.7 kB at 6.6 kB/s)
+[INFO] The following dependencies in Dependencies have newer versions:
+[INFO]   io.github.mweirauch:micrometer-jvm-extras ............. 0.2.2 -> 0.3.0
+[INFO]   io.jsonwebtoken:jjwt-api ............................ 0.12.6 -> 0.13.0
+[INFO]   io.jsonwebtoken:jjwt-impl ........................... 0.12.6 -> 0.13.0
+[INFO]   io.jsonwebtoken:jjwt-jackson ........................ 0.12.6 -> 0.13.0
+[INFO]   io.micrometer:micrometer-registry-prometheus ..... 1.15.1 -> 1.18.0-M1
+[INFO]   net.logstash.logback:logstash-logback-encoder ............. 8.0 -> 9.0
+[INFO]   org.flywaydb:flyway-core ............................ 11.7.2 -> 13.5.0
+[INFO]   org.flywaydb:flyway-database-postgresql ............. 11.7.2 -> 13.5.0
+[INFO]   org.kohsuke:github-api ............................. 1.321 -> 2.0-rc.7
+[INFO]   org.mapstruct:mapstruct ......................... 1.6.3 -> 1.7.0.Beta2
+[INFO]   org.passay:passay ..................................... 1.6.6 -> 2.0.0
+[INFO]   org.postgresql:postgresql .......................... 42.7.7 -> 42.7.13
+[INFO]   org.projectlombok:lombok .......................... 1.18.46 -> 1.18.48
+[INFO]   org.springdoc:springdoc-openapi-starter-webmvc-ui ..... 2.8.9 -> 3.1.0
+[INFO]   org.springframework.batch:spring-batch-test ........ 5.2.2 -> 6.1.0-M1
+[INFO]   org.springframework.boot:spring-boot-starter-actuator ...
+[INFO]                                                        3.5.3 -> 4.2.0-M1
+[INFO]   org.springframework.boot:spring-boot-starter-batch ...
+[INFO]                                                        3.5.3 -> 4.2.0-M1
+[INFO]   org.springframework.boot:spring-boot-starter-data-jpa ...
+[INFO]                                                        3.5.3 -> 4.2.0-M1
+[INFO]   org.springframework.boot:spring-boot-starter-data-mongodb ...
+[INFO]                                                        3.5.3 -> 4.2.0-M1
+[INFO]   org.springframework.boot:spring-boot-starter-data-redis ...
+[INFO]                                                        3.5.3 -> 4.2.0-M1
+[INFO]   org.springframework.boot:spring-boot-starter-security ...
+[INFO]                                                        3.5.3 -> 4.2.0-M1
+[INFO]   org.springframework.boot:spring-boot-starter-test ...
+[INFO]                                                        3.5.3 -> 4.2.0-M1
+[INFO]   org.springframework.boot:spring-boot-starter-validation ...
+[INFO]                                                        3.5.3 -> 4.2.0-M1
+[INFO]   org.springframework.boot:spring-boot-starter-web ... 3.5.3 -> 4.2.0-M1
+[INFO]   org.springframework.boot:spring-boot-testcontainers ...
+[INFO]                                                        3.5.3 -> 4.2.0-M1
+[INFO]   org.springframework.kafka:spring-kafka ............. 3.3.7 -> 4.2.0-M1
+[INFO]   org.springframework.kafka:spring-kafka-test ........ 3.3.7 -> 4.2.0-M1
+[INFO]   org.springframework.security:spring-security-test ...
+[INFO]                                                        6.5.1 -> 7.2.0-M1
+[INFO]   org.testcontainers:junit-jupiter .................... 1.21.2 -> 1.21.4
+[INFO]   org.testcontainers:mongodb .......................... 1.21.2 -> 1.21.4
+[INFO]   org.testcontainers:postgresql ....................... 1.21.2 -> 1.21.4
+[INFO] 
+Downloading from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-maven-plugin/maven-metadata.xml
+Progress (1): 4.6 kBProgress (1): 9.2 kBProgress (1): 10 kB                    Downloaded from central: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-maven-plugin/maven-metadata.xml (10 kB at 119 kB/s)
+[INFO] The following dependencies in pluginManagement of plugins have newer versions:
+[INFO]   org.springframework.boot:spring-boot-maven-plugin ...
+[INFO]                                                        3.5.3 -> 4.2.0-M1
+[INFO] 
+Downloading from central: https://repo.maven.apache.org/maven2/org/pitest/pitest-junit5-plugin/maven-metadata.xml
+Progress (1): 1.0 kB                    Downloaded from central: https://repo.maven.apache.org/maven2/org/pitest/pitest-junit5-plugin/maven-metadata.xml (1.0 kB at 11 kB/s)
+[INFO] No dependencies in Plugin Dependencies have newer versions.
+[INFO] 
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  3.649 s
+[INFO] Finished at: 2026-09-06T00:47:33-03:00
+[INFO] ------------------------------------------------------------------------
+```

--- a/JPPhotoManagerWeb/docs/reports/dependency-staleness/DEPENDENCY_STALENESS_REPORT_2026-09-06_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/dependency-staleness/DEPENDENCY_STALENESS_REPORT_2026-09-06_frontend.md
@@ -1,0 +1,40 @@
+# Dependency Staleness Report (frontend) — 2026-09-06
+
+**Commit:** c0f4ef0
+**Generated:** 2026-09-06T03:07:38.892Z
+**Scope:** frontend/package.json
+
+**Total dependencies (direct):** 47
+**Outdated:** 29 (6 major, 9 minor, 14 patch behind)
+
+| Package | Current | Wanted | Latest | Behind by |
+| --- | --- | --- | --- | --- |
+| @types/node | 22.20.1 | 22.20.1 | 26.4.1 | major |
+| @swimlane/ngx-charts | 24.0.0-alpha.1 | 24.0.2 | 25.0.2 | major |
+| cypress | 15.20.1 | 15.21.1 | 16.0.0 | major |
+| eslint | 9.39.4 | 9.39.5 | 10.10.0 | major |
+| @babel/core | 7.29.7 | 7.29.7 | 8.0.1 | major |
+| typescript | 6.0.3 | 6.0.3 | 7.0.2 | major |
+| @angular-eslint/builder | 22.1.0 | 22.2.0 | 22.2.0 | minor |
+| @angular-eslint/eslint-plugin | 22.1.0 | 22.2.0 | 22.2.0 | minor |
+| @angular-eslint/eslint-plugin-template | 22.1.0 | 22.2.0 | 22.2.0 | minor |
+| @angular-eslint/template-parser | 22.1.0 | 22.2.0 | 22.2.0 | minor |
+| @typescript-eslint/eslint-plugin | 8.67.0 | 8.69.0 | 8.69.0 | minor |
+| @typescript-eslint/parser | 8.67.0 | 8.69.0 | 8.69.0 | minor |
+| typescript-eslint | 8.67.0 | 8.69.0 | 8.69.0 | minor |
+| knip | 6.32.2 | 6.34.0 | 6.34.0 | minor |
+| zone.js | 0.15.1 | 0.15.1 | 0.16.3 | minor |
+| @angular/build | 22.1.3 | 22.1.7 | 22.1.7 | patch |
+| @angular/cli | 22.1.3 | 22.1.7 | 22.1.7 | patch |
+| @angular/cdk | 22.1.1 | 22.1.5 | 22.1.5 | patch |
+| @angular/common | 22.1.1 | 22.1.5 | 22.1.5 | patch |
+| @angular/compiler | 22.1.1 | 22.1.5 | 22.1.5 | patch |
+| @angular/compiler-cli | 22.1.1 | 22.1.5 | 22.1.5 | patch |
+| @angular/core | 22.1.1 | 22.1.5 | 22.1.5 | patch |
+| @angular/forms | 22.1.1 | 22.1.5 | 22.1.5 | patch |
+| @angular/material | 22.1.1 | 22.1.5 | 22.1.5 | patch |
+| @angular/platform-browser | 22.1.1 | 22.1.5 | 22.1.5 | patch |
+| @angular/router | 22.1.1 | 22.1.5 | 22.1.5 | patch |
+| @angular/service-worker | 22.1.1 | 22.1.5 | 22.1.5 | patch |
+| @secretlint/secretlint-rule-preset-recommend | 13.0.4 | 13.0.5 | 13.0.5 | patch |
+| secretlint | 13.0.4 | 13.0.5 | 13.0.5 | patch |

--- a/JPPhotoManagerWeb/docs/reports/dependency-vulnerabilities/SCA_REPORT_2026-09-06_backend.md
+++ b/JPPhotoManagerWeb/docs/reports/dependency-vulnerabilities/SCA_REPORT_2026-09-06_backend.md
@@ -1,0 +1,37 @@
+# Dependency Vulnerability (SCA) Report (backend) — 2026-09-06
+
+**Commit:** c0f4ef0
+**Generated:** 2026-09-06T03:47:38Z
+**Scope:** backend Maven dependency tree, compile scope (OSV.dev batch query, https://api.osv.dev)
+
+**86 known vulnerabilities across the resolved dependency tree.**
+
+| Package | Vuln count | OSV IDs |
+| --- | --- | --- |
+| org.springframework.boot:spring-boot:3.5.3 | 1 | GHSA-wwpq-f5c3-7hvx |
+| org.apache.logging.log4j:log4j-api:2.24.3 | 1 | GHSA-qv9r-c865-cp47 |
+| org.apache.tomcat.embed:tomcat-embed-core:10.1.42 | 22 | GHSA-25xr-qj8w-c4vf, GHSA-563x-q5rq-57qp, GHSA-5m62-pw8w-7w9f, GHSA-5mp6-jrq3-r938, GHSA-9m3c-qcxr-9x87, GHSA-9m89-8frq-c98c, GHSA-9xv2-5v5q-p794, GHSA-fpj8-gq4v-p354, GHSA-fv25-8xcx-gqjc, GHSA-gcx9-497g-6cp6, GHSA-gqp3-2cvr-x8m3, GHSA-gx5v-xp9w-j4cg, GHSA-h3x4-894j-xpx5, GHSA-h6fc-48rj-7qqh, GHSA-hgrr-935x-pq79, GHSA-mgp5-rv84-w37q, GHSA-r29c-68gh-xp6x, GHSA-rv64-5gf8-9qq8, GHSA-vfww-5hm6-hx2j, GHSA-wmwf-9ccg-fff5, GHSA-wr62-c79q-cv37, GHSA-x4m4-345f-5h5g |
+| org.springframework:spring-web:6.2.8 | 1 | GHSA-7m2p-62gw-p8qq |
+| org.springframework:spring-webmvc:6.2.8 | 12 | GHSA-3chg-m5w7-qfv5, GHSA-4773-3jfm-qmx3, GHSA-6hcq-hmm3-jj3c, GHSA-6p4f-wcwh-5vvm, GHSA-72pg-x5f8-j25j, GHSA-957g-f97v-vppc, GHSA-cjpg-rgq5-fr37, GHSA-h3qp-gqrc-q736, GHSA-mq64-j8f9-9gcj, GHSA-r936-gwx5-v52f, GHSA-wg35-8jpf-2xv3, GHSA-x23c-287f-qqv5 |
+| org.springframework:spring-expression:6.2.8 | 3 | GHSA-9f52-rjqv-25qv, GHSA-r5w3-xv2f-j59q, GHSA-wxpp-56q6-5pcg |
+| org.springframework.data:spring-data-commons:3.5.1 | 4 | GHSA-5m4m-73w9-8433, GHSA-5vpf-xvv7-c8vh, GHSA-88fw-v6x4-3f58, GHSA-9fw2-h3hf-293r |
+| org.springframework.boot:spring-boot-starter-actuator:3.5.3 | 2 | GHSA-8hfc-fq58-r658, GHSA-mgvc-8q2h-5pgc |
+| io.micrometer:micrometer-core:1.15.1 | 2 | GHSA-g3pr-3p32-fp23, GHSA-w737-wx49-qj23 |
+| org.postgresql:postgresql:42.7.7 | 2 | GHSA-98qh-xjc8-98pq, GHSA-j92g-9f8w-j867 |
+| com.fasterxml.jackson.core:jackson-core:2.19.1 | 2 | GHSA-72hv-8253-57qq, GHSA-r7wm-3cxj-wff9 |
+| org.apache.commons:commons-lang3:3.17.0 | 1 | GHSA-j288-q9x7-2f5v |
+| com.fasterxml.jackson.core:jackson-databind:2.19.1 | 5 | GHSA-3pjw-73gf-8qr5, GHSA-5jmj-h7xm-6q6v, GHSA-hgj6-7826-r7m5, GHSA-j3rv-43j4-c7qm, GHSA-rmj7-2vxq-3g9f |
+| io.netty:netty-handler:4.1.122.Final | 3 | GHSA-3qp7-7mw8-wx86, GHSA-c653-97m9-rcg9, GHSA-x4gw-5cx5-pgmh |
+| io.netty:netty-codec:4.1.122.Final | 3 | GHSA-3p8m-j85q-pgmj, GHSA-558v-64gr-wgg4, GHSA-mj4r-2hfc-f8p6 |
+| org.springframework.data:spring-data-keyvalue:3.5.1 | 1 | GHSA-xg2j-3hj6-pc24 |
+| org.springframework.data:spring-data-mongodb:4.5.1 | 2 | GHSA-5whc-4q84-fj73, GHSA-hc43-m36c-8v33 |
+| org.springframework.kafka:spring-kafka:3.3.7 | 3 | GHSA-53w6-v7cv-fc9h, GHSA-xq69-5h5v-x9x4, GHSA-xvfq-4q6q-gxx7 |
+| org.springframework.retry:spring-retry:2.0.12 | 1 | GHSA-2827-2mxx-j8pv |
+| org.apache.kafka:kafka-clients:3.9.1 | 2 | GHSA-5qcv-4rpc-jp93, GHSA-wf66-mphr-4c4r |
+| ch.qos.logback:logback-core:1.5.18 | 4 | GHSA-25qh-j22f-pwp8, GHSA-jhq6-gfmj-v8fx, GHSA-p47f-322f-whfh, GHSA-qqpg-mvqg-649v |
+| org.springframework.security:spring-security-web:6.5.1 | 3 | GHSA-293q-567p-wmwq, GHSA-mf92-479x-3373, GHSA-x2r2-rvhq-2mqv |
+| org.springframework:spring-core:6.2.8 | 2 | GHSA-659m-px2c-25wj, GHSA-jmp9-x22r-554x |
+| org.springframework.boot:spring-boot-autoconfigure:3.5.3 | 1 | GHSA-ggg2-9786-hwc8 |
+| org.springframework.security:spring-security-core:6.5.1 | 3 | GHSA-8v5q-rhf3-jphm, GHSA-vxf7-qj7q-83fh, GHSA-x2wq-9x2f-fhj7 |
+
+Look up any ID at https://osv.dev/vulnerability/<id> for severity, affected version ranges, and the fixed version — the batch endpoint used here returns IDs only, not full advisory detail, to keep this a fast routine check rather than one HTTP call per finding. A vulnerability in a *test-scope-only* transitive dependency (not shown here — this query is compile-scope only) is lower priority than one reachable at runtime.

--- a/JPPhotoManagerWeb/docs/reports/dependency-vulnerabilities/SCA_REPORT_2026-09-06_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/dependency-vulnerabilities/SCA_REPORT_2026-09-06_frontend.md
@@ -1,0 +1,26 @@
+# Dependency Vulnerability (SCA) Report (frontend) — 2026-09-06
+
+**Commit:** c0f4ef0
+**Generated:** 2026-09-06T03:45:47.913Z
+**Scope:** `frontend/` npm dependency tree (`npm audit`, npm's own advisory database)
+
+**14 vulnerable package(s):** 0 critical, 7 high, 7 moderate, 0 low, 0 info.
+
+| Package | Severity | Vulnerable range | Fix available | Advisory |
+| --- | --- | --- | --- | --- |
+| @angular-devkit/build-angular | high | <=22.2.0-next.0 | yes | less; webpack-dev-server |
+| brace-expansion | high | <=1.1.17 || 2.0.0 - 2.1.3 || 3.0.0 - 5.0.8 | yes | brace-expansion: Large numeric range defeats documented `max` DoS protection; brace-expansion: DoS via exponential-time expansion of consecutive non-expanding {} groups; brace-expansion: DoS via exponential-time expansion of consecutive non-expanding {} groups; brace-expansion: DoS via exponential-time expansion of consecutive non-expanding {} groups; brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash; brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash; brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash; brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation; brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation; brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation |
+| fast-uri | high | 3.0.0 - 3.1.5 | yes | fast-uri vulnerable to host confusion via literal backslash authority delimiter; fast-uri vulnerable to host confusion via backslash authority introducer; fast-uri vulnerable to path traversal via percent-encoded dot segments; fast-uri vulnerable to host confusion via percent-encoded authority delimiters; fast-uri vulnerable to server-side request forgery via malformed IPv6 normalization; fast-uri vulnerable to host confusion via percent-encoded scheme normalization; fast-uri vulnerable to host confusion via failed IDN canonicalization |
+| image-size | high | * | yes | image-size: ICNS parser allows denial of service through an infinite loop; image-size: JXL and HEIF parsers allow denial of service through infinite loops |
+| js-yaml | high | <=3.15.0 | yes | JS-YAML: Quadratic-complexity DoS in merge key handling via repeated aliases; js-yaml: YAML merge-key chains can force quadratic CPU consumption; JS-YAML: Quadratic CPU consumption in !!omap resolution (3.x and 4.x) — CVE-2026-59870 fix not backported |
+| less | high | 2.2.0 - 4.6.7 | yes | image-size |
+| tmp | high | <0.2.6 | yes | tmp has Path Traversal via unsanitized prefix/postfix that enables directory escape |
+| body-parser | moderate | 1.20.5 - 1.20.6 | yes | qs |
+| express | moderate | 4.22.2 | yes | body-parser; qs |
+| qs | moderate | 2.2.5 - 6.15.3 | yes | qs has a remotely triggerable DoS: qs.stringify crashes with TypeError on null/undefined entries in comma-format arrays when encodeValuesOnly is set; qs array-limit bypass via bracket-key comma parsing; qs: Denial of Service via Attacker Controlled isBuffer |
+| sockjs | moderate | >=0.3.17 | yes | uuid |
+| typed-rest-client | moderate | >=2.3.1 | yes | qs |
+| uuid | moderate | <11.1.1 | yes | uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided |
+| webpack-dev-server | moderate | 2.0.0-beta - 5.2.6 | yes | sockjs |
+
+Critical/high severity with a fix available is the priority — `npm audit fix` (or `--force` for a breaking major bump, review the changelog first) resolves those directly. A vulnerability with no fix available needs a judgment call: is the vulnerable code path actually reachable in this app (many advisories are in a devDependency's own build tooling, never shipped or executed against untrusted input), and if so, is there an interim mitigation until upstream publishes a fix.

--- a/JPPhotoManagerWeb/docs/reports/e2e-run/E2E_RUN_REPORT_2026-09-06_mocked.md
+++ b/JPPhotoManagerWeb/docs/reports/e2e-run/E2E_RUN_REPORT_2026-09-06_mocked.md
@@ -1,0 +1,17 @@
+# E2E Run Report (mocked) — 2026-09-06
+
+**Commit:** c0f4ef0
+**Generated:** 2026-09-06T03:08:20.020Z
+**Total duration:** 15.0s
+**Tests:** 23 (23 passed, 0 failed, 0 skipped)
+**Flaky tests (needed a retry to pass):** 0
+
+## Slowest 5 specs
+
+| Spec | Duration (s) | Tests |
+| --- | --- | --- |
+| cypress\e2e\mocked\gallery.cy.ts | 2.7 | 5 |
+| cypress\e2e\mocked\admin-users.cy.ts | 1.8 | 2 |
+| cypress\e2e\mocked\login.cy.ts | 1.4 | 2 |
+| cypress\e2e\mocked\albums.cy.ts | 1.2 | 2 |
+| cypress\e2e\mocked\convert.cy.ts | 1.1 | 2 |

--- a/JPPhotoManagerWeb/docs/reports/license-compliance/LICENSE_COMPLIANCE_REPORT_2026-09-06_backend.md
+++ b/JPPhotoManagerWeb/docs/reports/license-compliance/LICENSE_COMPLIANCE_REPORT_2026-09-06_backend.md
@@ -1,0 +1,14 @@
+# License Compliance Report (backend) — 2026-09-06
+
+**Commit:** c0f4ef0
+**Generated:** 2026-09-06T03:47:33Z
+**Scope:** backend Maven dependency tree, excluding test scope (license-maven-plugin add-third-party)
+
+**147 package(s) scanned, 0 need action, 1 previously reviewed and accepted.**
+
+## Previously reviewed and accepted
+
+| Component | License(s) | Why it's accepted |
+| --- | --- | --- |
+| jaudiotagger (net.jthink:jaudiotagger:3.0.1 - https://bitbucket.org/ijabz/jaudiotagger) | LGPL | LGPLv3. Confirmed compile-scope, unmodified dependency (no vendored/patched jaudiotagger source anywhere in this repo) consumed only through its public API in a single adapter class (infrastructure/service/AudioMetadataService.java, ~15 lines: AudioFileIO.read() plus getters on the returned AudioFile/Tag/Artwork) — exactly the unmodified dynamic-linking case LGPL permits without imposing copyleft on the consuming application. The only realistic permissive alternative (mp3agic, MIT) is MP3/ID3-only, so swapping would risk a functional regression for FLAC/OGG/M4A files versus jaudiotagger's format-agnostic reader, for zero compliance benefit. |
+

--- a/JPPhotoManagerWeb/docs/reports/license-compliance/LICENSE_COMPLIANCE_REPORT_2026-09-06_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/license-compliance/LICENSE_COMPLIANCE_REPORT_2026-09-06_frontend.md
@@ -1,0 +1,9 @@
+# License Compliance Report (frontend) — 2026-09-06
+
+**Commit:** c0f4ef0
+**Generated:** 2026-09-06T03:45:43.172Z
+**Scope:** `frontend/` npm dependency tree (license-checker-rseidelsohn, excludes private/unpublished packages)
+
+**1324 package(s) scanned, 0 flagged** (copyleft license or no resolvable license).
+
+No copyleft or unresolvable licenses found among scanned dependencies.

--- a/JPPhotoManagerWeb/docs/reports/lighthouse/LIGHTHOUSE_REPORT_2026-09-06_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/lighthouse/LIGHTHOUSE_REPORT_2026-09-06_frontend.md
@@ -1,0 +1,16 @@
+# Lighthouse Report (frontend) — 2026-09-06
+
+**Commit:** c0f4ef0
+**Generated:** 2026-09-06T03:02:46.487Z
+**Build:** production (`ng build --configuration production`), self-hosted — not the `ng serve` dev build, so scores reflect real optimized output.
+**Scope:** /login — the only route reachable without an authenticated session; every other route requires signing in first, which this report doesn't attempt to simulate.
+
+| Route | Performance | Accessibility | Best Practices | SEO |
+| --- | --- | --- | --- | --- |
+| /login | 66 | 98 | 100 | 82 |
+
+## Accessibility audit failures
+
+| Route | Audit |
+| --- | --- |
+| /login | Document does not have a main landmark. (`landmark-one-main`) |

--- a/JPPhotoManagerWeb/docs/reports/route-coverage/ROUTE_COVERAGE_REPORT_2026-09-06_frontend.md
+++ b/JPPhotoManagerWeb/docs/reports/route-coverage/ROUTE_COVERAGE_REPORT_2026-09-06_frontend.md
@@ -1,0 +1,24 @@
+# Route E2E Coverage Report (frontend) — 2026-09-06
+
+**Commit:** c0f4ef0
+**Generated:** 2026-09-06T03:02:04.208Z
+**Scope:** 12 declared routes; 17 E2E spec files (5 real-backend, 12 mocked)
+
+Whether each declared route has at least one literal `cy.visit(...)` in either E2E tier. A route built from a variable rather than a string literal won't be detected by this scan; a parameterized route (`albums/:id`) is matched by its static path prefix instead of an exact string.
+
+| Route | Real-backend tier | Mocked tier |
+| --- | --- | --- |
+| /admin/users | ✓ | ✓ |
+| /albums | ✓ | ✓ |
+| /albums/:id | ✓ | ✓ |
+| /analytics | ✓ | ✓ |
+| /convert | ✓ | ✓ |
+| /duplicates | ✓ | ✓ |
+| /gallery | ✓ | ✓ |
+| /home | ✓ | ✓ |
+| /login | ✓ | ✓ |
+| /profile/sessions | ✓ | ✓ |
+| /recycle-bin | ✓ | ✓ |
+| /sync | ✓ | ✓ |
+
+**Routes with no E2E coverage in either tier:** none

--- a/JPPhotoManagerWeb/docs/reports/secrets-scan/SECRETS_SCAN_REPORT_2026-09-06.md
+++ b/JPPhotoManagerWeb/docs/reports/secrets-scan/SECRETS_SCAN_REPORT_2026-09-06.md
@@ -1,0 +1,9 @@
+# Secrets Scan Report — 2026-09-06
+
+**Commit:** c0f4ef0
+**Generated:** 2026-09-06T03:45:26.958Z
+**Scope:** whole repository (secretlint, `.gitignore`-respecting — see `JPPhotoManagerWeb/frontend/.secretlintrc.json` / `.secretlintignore`)
+
+**Findings:** 0 potential secret(s).
+
+No secrets detected.

--- a/JPPhotoManagerWeb/docs/reports/type-coverage/TYPE_COVERAGE_REPORT_2026-09-06.md
+++ b/JPPhotoManagerWeb/docs/reports/type-coverage/TYPE_COVERAGE_REPORT_2026-09-06.md
@@ -1,0 +1,45 @@
+# Type Coverage Report — 2026-09-06
+
+**Commit:** c0f4ef0
+**Generated:** 2026-09-06T03:01:49.166Z
+**Scope:** frontend/tsconfig.app.json (application source, excludes *.cy.ts/*.spec.ts)
+
+**Type coverage:** 99.78% (9441 / 9462 identifiers have a non-`any` type)
+**Untyped (`any`) identifiers:** 21, across 6 file(s)
+
+## Files with the most `any`-typed identifiers
+
+| File | Count |
+| --- | --- |
+| src/app/core/interceptors/auth.interceptor.ts | 9 |
+| src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts | 5 |
+| src/app/features/sync/sync.component.ts | 2 |
+| src/app/features/convert/convert.component.ts | 2 |
+| src/main.ts | 2 |
+| src/app/app.component.ts | 1 |
+
+## Every uncovered location
+
+| File | Line | Identifier |
+| --- | --- | --- |
+| src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts | 96 | `message` |
+| src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts | 96 | `error` |
+| src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts | 96 | `message` |
+| src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts | 97 | `error` |
+| src/app/features/gallery/batch-rename-dialog/batch-rename-dialog.component.ts | 97 | `message` |
+| src/app/features/sync/sync.component.ts | 114 | `data` |
+| src/app/features/sync/sync.component.ts | 118 | `data` |
+| src/app/features/convert/convert.component.ts | 114 | `data` |
+| src/app/features/convert/convert.component.ts | 118 | `data` |
+| src/app/core/interceptors/auth.interceptor.ts | 10 | `error` |
+| src/app/core/interceptors/auth.interceptor.ts | 30 | `error` |
+| src/app/core/interceptors/auth.interceptor.ts | 32 | `error` |
+| src/app/core/interceptors/auth.interceptor.ts | 39 | `refreshError` |
+| src/app/core/interceptors/auth.interceptor.ts | 42 | `refreshError` |
+| src/app/core/interceptors/auth.interceptor.ts | 45 | `refreshError` |
+| src/app/core/interceptors/auth.interceptor.ts | 51 | `error` |
+| src/app/core/interceptors/auth.interceptor.ts | 59 | `error` |
+| src/app/core/interceptors/auth.interceptor.ts | 63 | `error` |
+| src/app/app.component.ts | 118 | `data` |
+| src/main.ts | 5 | `err` |
+| src/main.ts | 5 | `err` |


### PR DESCRIPTION
## Summary
First fresh run of the newly-added `quality-metrics` skill in this repo (both frontend and backend halves). Most categories are flat, confirming the app itself has been essentially unchanged since the 2026-08-14/15 baseline, but the sweep surfaced two real drifts external to the codebase:

- **Frontend dependency staleness jumped 20 → 29 outdated** (minor-version count 1 → 9) — worth a `dependency-upgrade` pass.
- **Dependency vulnerability counts rose on both sides** (frontend 12 → 14, backend 82 → 86) as new advisories were published upstream (OSV.dev / npm audit), not from any code change here.

It also surfaced a tooling gap worth a separate follow-up: the frontend `a11y` report failed to connect to its dev server (`Cypress could not verify that this server is running`) but still wrote a result identical to the stale baseline — flagged as unreliable in the trend report rather than treated as a genuine measurement. Unlike the a11y script pattern used elsewhere, this one doesn't appear to start its own dev server first.

## Test plan
- [x] Ran `bash scripts/run-all-quality-reports.sh` end to end — both frontend and backend summaries reported `OK` for every category except mutation (skipped by default, as intended)
- [x] Cross-checked every fresh report's extracted values against the skill's file-pattern/extraction tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)